### PR TITLE
0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.9.2](https://github.com/Okipa/laravel-bootstrap-components/releases/tag/0.9.2)
+2019-09-03
+- Fixed default config for `datetime()` component => the default format has been corrected to `Y-m-d\TH:i`, in order to respect the `datetime-local` input type standards.
+
 ## [0.9.1](https://github.com/Okipa/laravel-bootstrap-components/releases/tag/0.9.1)
 2019-08-26
 - Fixed html generation after https://github.com/Okipa/laravel-html-helper upgrade.

--- a/config/bootstrap-components.php
+++ b/config/bootstrap-components.php
@@ -65,7 +65,7 @@ return [
             'view'                 => 'bootstrap-components.form.input',
             'prepend'              => '<i class="fas fa-calendar-alt"></i>',
             'append'               => null,
-            'format'               => 'd/m/Y H:i',
+            'format'               => 'Y-m-d\TH:i',
             'labelPositionedAbove' => true,
             'legend'               => 'bootstrap-components.legend.datetime',
             'classes'              => [


### PR DESCRIPTION
- Fixed default config for `datetime()` component => the default format has been corrected to `Y-m-d\TH:i`, in order to respect the `datetime-local` input type standards.