### PR TITLE
0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.9.2](https://github.com/Okipa/laravel-bootstrap-components/releases/tag/0.9.2)
+2019-09-03
+- Fixed default config for `datetime()` component => the default format has been corrected to `Y-m-d\TH:i`, in order to respect the `datetime-local` input type standards.
+
 ## [0.9.1](https://github.com/Okipa/laravel-bootstrap-components/releases/tag/0.9.1)
 2019-08-26
 - Fixed html generation after https://github.com/Okipa/laravel-html-helper upgrade.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## [0.9.3](https://github.com/Okipa/laravel-bootstrap-components/releases/tag/0.10.0)
+2019-09-04
+- Fixed default config for `bsDate()` component => the default format has been corrected to `Y-m-d`, in order to respect the `date` input type standards.
+
 ## [0.9.2](https://github.com/Okipa/laravel-bootstrap-components/releases/tag/0.9.2)
 2019-09-03
-- Fixed default config for `datetime()` component => the default format has been corrected to `Y-m-d\TH:i`, in order to respect the `datetime-local` input type standards.
+- Fixed default config for `bsDatetime()` component => the default format has been corrected to `Y-m-d\TH:i`, in order to respect the `datetime-local` input type standards.
 
 ## [0.9.1](https://github.com/Okipa/laravel-bootstrap-components/releases/tag/0.9.1)
 2019-08-26

--- a/config/bootstrap-components.php
+++ b/config/bootstrap-components.php
@@ -85,7 +85,7 @@ return [
             'view'                 => 'bootstrap-components.form.input',
             'prepend'              => '<i class="fas fa-calendar-alt"></i>',
             'append'               => null,
-            'format'               => 'd/m/Y',
+            'format'               => 'Y-m-d',
             'labelPositionedAbove' => true,
             'legend'               => 'bootstrap-components.legend.date',
             'classes'              => [

--- a/config/bootstrap-components.php
+++ b/config/bootstrap-components.php
@@ -65,7 +65,7 @@ return [
             'view'                 => 'bootstrap-components.form.input',
             'prepend'              => '<i class="fas fa-calendar-alt"></i>',
             'append'               => null,
-            'format'               => 'd/m/Y H:i',
+            'format'               => 'Y-m-d\TH:i',
             'labelPositionedAbove' => true,
             'legend'               => 'bootstrap-components.legend.datetime',
             'classes'              => [


### PR DESCRIPTION
- Fixed default config for `bsDate()` component => the default format has been corrected to `Y-m-d`, in order to respect the `date` input type standards.