### PR TITLE
2.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## [2.1.5](https://github.com/Okipa/laravel-bootstrap-components/compare/2.1.3...2.1.5)
+## [2.1.6](https://github.com/Okipa/laravel-bootstrap-components/compare/2.1.5...2.1.6)
+
+2020-04-02
+
+* Fixed a bug preventing the form components to display errors on input with array name (eg. `name[0]`).
+* Fixed a wrong default id generation for the for the form components on inputs with array name (`text-name0` will now be correctly displayed `text-name-0`).
+
+## [2.1.5](https://github.com/Okipa/laravel-bootstrap-components/compare/2.1.4...2.1.5)
 
 2020-04-01
 

--- a/src/Components/Form/Abstracts/CheckableAbstract.php
+++ b/src/Components/Form/Abstracts/CheckableAbstract.php
@@ -4,26 +4,9 @@ namespace Okipa\LaravelBootstrapComponents\Components\Form\Abstracts;
 
 abstract class CheckableAbstract extends FormAbstract
 {
-    /**
-     * The input checked status.
-     *
-     * @property bool $checked
-     */
+    /** @property bool $checked */
     protected $checked;
 
-    /** @inheritDoc */
-    protected function setLabelPositionedAbove(): bool
-    {
-        return true; // unused
-    }
-
-    /**
-     * Set the checkable component check status.
-     *
-     * @param bool $checked
-     *
-     * @return $this
-     */
     public function checked(bool $checked = true): self
     {
         $this->checked = $checked;
@@ -31,15 +14,16 @@ abstract class CheckableAbstract extends FormAbstract
         return $this;
     }
 
-    /** @inheritDoc */
+    protected function setLabelPositionedAbove(): bool
+    {
+        return true; // unused
+    }
+
     protected function getComponentHtmlAttributes(): array
     {
         return array_merge(parent::getComponentHtmlAttributes(), $this->getChecked() ? ['checked' => 'checked'] : []);
     }
 
-    /**
-     * @return bool
-     */
     protected function getChecked(): bool
     {
         $old = old($this->getName());

--- a/src/Components/Form/Abstracts/FormAbstract.php
+++ b/src/Components/Form/Abstracts/FormAbstract.php
@@ -404,7 +404,7 @@ abstract class FormAbstract extends ComponentAbstract
     protected function getValidationClass(): ?string
     {
         if (session()->has('errors')) {
-            return session()->get('errors')->has($this->getName())
+            return session()->get('errors')->has($this->convertArrayNameInNotation())
                 ? ($this->getDisplayFailure() ? 'is-invalid' : null)
                 : ($this->getDisplaySuccess() ? 'is-valid' : null);
         }
@@ -412,17 +412,22 @@ abstract class FormAbstract extends ComponentAbstract
         return null;
     }
 
+    protected function convertArrayNameInNotation(string $notation = '.'): string
+    {
+        return str_replace(['[', ']'], [$notation, ''], $this->getName());
+    }
+
     /**
      * @return string|null
      */
     protected function getErrorMessage(): ?string
     {
-        return optional(session()->get('errors'))->first($this->getName());
+        return optional(session()->get('errors'))->first($this->convertArrayNameInNotation());
     }
 
     /** @inheritDoc */
     protected function getComponentId(): string
     {
-        return parent::getComponentId() ?? $this->getType() . '-' . Str::slug($this->getName());
+        return parent::getComponentId() ?? $this->getType() . '-' . Str::slug($this->convertArrayNameInNotation('-'));
     }
 }

--- a/src/Components/Form/Abstracts/RadioAbstract.php
+++ b/src/Components/Form/Abstracts/RadioAbstract.php
@@ -9,16 +9,13 @@ abstract class RadioAbstract extends CheckableAbstract
 {
     use RadioValidityChecks;
 
-    /** @inheritDoc */
     protected function getComponentId(): string
     {
         return $this->componentId
-            ?? $this->getType() . '-' . Str::slug($this->convertArrayNameInNotation('-')) . '-' . Str::slug($this->getValue());
+            ?? $this->getType() . '-' . Str::slug($this->convertArrayNameInNotation('-')) . '-'
+            . Str::slug($this->getValue());
     }
 
-    /**
-     * @return bool
-     */
     protected function getChecked(): bool
     {
         $old = old($this->getName());

--- a/src/Components/Form/Abstracts/RadioAbstract.php
+++ b/src/Components/Form/Abstracts/RadioAbstract.php
@@ -13,7 +13,7 @@ abstract class RadioAbstract extends CheckableAbstract
     protected function getComponentId(): string
     {
         return $this->componentId
-            ?? $this->getType() . '-' . Str::slug($this->getName()) . '-' . Str::slug($this->getValue());
+            ?? $this->getType() . '-' . Str::slug($this->convertArrayNameInNotation('-')) . '-' . Str::slug($this->getValue());
     }
 
     /**

--- a/tests/Unit/Form/Abstracts/InputRadioTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/InputRadioTestAbstract.php
@@ -236,8 +236,15 @@ abstract class InputRadioTestAbstract extends InputTestAbstract
     public function testDefaultComponentId()
     {
         $html = $this->getComponent()->name('name')->toHtml();
-        $this->assertStringContainsString('<input id="' . $this->getComponentType() . '-name-value"', $html);
         $this->assertStringContainsString(' for="' . $this->getComponentType() . '-name-value"', $html);
+        $this->assertStringContainsString('<input id="' . $this->getComponentType() . '-name-value"', $html);
+    }
+
+    public function testDefaultComponentIdWithArrayName()
+    {
+        $html = $this->getComponent()->name('name[0]')->toHtml();
+        $this->assertStringContainsString(' for="' . $this->getComponentType() . '-name-0-value"', $html);
+        $this->assertStringContainsString('<input id="' . $this->getComponentType() . '-name-0-value"', $html);
     }
 
     public function testSetCustomContainerClasses()

--- a/tests/Unit/Form/Abstracts/InputTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/InputTestAbstract.php
@@ -345,6 +345,16 @@ abstract class InputTestAbstract extends BootstrapComponentsTestCase
         $this->assertStringNotContainsString($errors->first('name'), $html);
     }
 
+    public function testDisplayFailureWithArrayName()
+    {
+        $errors = app(MessageBag::class)->add('name.0', 'Dummy error message.');
+        session()->put('errors', $errors);
+        $html = $this->getComponent()->name('name[0]')->render(compact('errors'));
+        $this->assertStringContainsString('is-invalid', $html);
+        $this->assertStringContainsString('<div class="invalid-feedback d-block">', $html);
+        $this->assertStringContainsString($errors->first('name'), $html);
+    }
+
     public function testSetNoContainerId()
     {
         $html = $this->getComponent()->name('name')->toHtml();
@@ -363,6 +373,13 @@ abstract class InputTestAbstract extends BootstrapComponentsTestCase
         $html = $this->getComponent()->name('name')->toHtml();
         $this->assertStringContainsString(' for="' . $this->getComponentType() . '-name"', $html);
         $this->assertStringContainsString('<input id="' . $this->getComponentType() . '-name"', $html);
+    }
+
+    public function testDefaultComponentIdWithArrayName()
+    {
+        $html = $this->getComponent()->name('name[0]')->toHtml();
+        $this->assertStringContainsString(' for="' . $this->getComponentType() . '-name-0"', $html);
+        $this->assertStringContainsString('<input id="' . $this->getComponentType() . '-name-0"', $html);
     }
 
     public function testSetComponentId()

--- a/tests/Unit/Form/Abstracts/SelectTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/SelectTestAbstract.php
@@ -575,6 +575,13 @@ abstract class SelectTestAbstract extends InputTestAbstract
         $this->assertStringContainsString('<select id="' . $this->getComponentType() . '-name"', $html);
     }
 
+    public function testDefaultComponentIdWithArrayName()
+    {
+        $html = $this->getComponent()->name('name[0]')->toHtml();
+        $this->assertStringContainsString(' for="' . $this->getComponentType() . '-name-0"', $html);
+        $this->assertStringContainsString('<select id="' . $this->getComponentType() . '-name-0"', $html);
+    }
+
     public function testSetComponentId()
     {
         $customComponentId = 'test-custom-component-id';

--- a/tests/Unit/Form/Abstracts/TextareaTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/TextareaTestAbstract.php
@@ -99,6 +99,13 @@ abstract class TextareaTestAbstract extends InputMultilingualTestAbstract
         $this->assertStringContainsString('<textarea id="' . $this->getComponentType() . '-name"', $html);
     }
 
+    public function testDefaultComponentIdWithArrayName()
+    {
+        $html = $this->getComponent()->name('name[0]')->toHtml();
+        $this->assertStringContainsString(' for="' . $this->getComponentType() . '-name-0"', $html);
+        $this->assertStringContainsString('<textarea id="' . $this->getComponentType() . '-name-0"', $html);
+    }
+
     public function testSetComponentId()
     {
         $customComponentId = 'custom-component-id';


### PR DESCRIPTION
* Fixed a bug preventing the form components to display errors on input with array name (eg. `name[0]`).
* Fixed a wrong default id generation for the for the form components on inputs with array name (`text-name0` will now be correctly displayed `text-name-0`).