### PR TITLE
2.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## [2.1.5](https://github.com/Okipa/laravel-bootstrap-components/compare/2.1.3...2.1.5)
+## [2.1.6](https://github.com/Okipa/laravel-bootstrap-components/compare/2.1.5...2.1.6)
+
+2020-04-02
+
+* Fixed a bug preventing the form components to display errors on input with array name (eg. `name[0]`).
+* Fixed a wrong default id generation for the for the form components on inputs with array name (`text-name0` will now be correctly displayed `text-name-0`).
+
+## [2.1.5](https://github.com/Okipa/laravel-bootstrap-components/compare/2.1.4...2.1.5)
 
 2020-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.1.7](https://github.com/Okipa/laravel-bootstrap-components/compare/2.1.6...2.1.7)
+
+2020-04-02
+
+* Fixed the form components pre-filling when defining an array name (eg. `name[0]`).
+* Fixed the placeholder generation when defining an array name (eg. `name[0]`).
+
 ## [2.1.6](https://github.com/Okipa/laravel-bootstrap-components/compare/2.1.5...2.1.6)
 
 2020-04-02

--- a/src/Components/Form/Abstracts/CheckableAbstract.php
+++ b/src/Components/Form/Abstracts/CheckableAbstract.php
@@ -4,26 +4,9 @@ namespace Okipa\LaravelBootstrapComponents\Components\Form\Abstracts;
 
 abstract class CheckableAbstract extends FormAbstract
 {
-    /**
-     * The input checked status.
-     *
-     * @property bool $checked
-     */
+    /** @property bool $checked */
     protected $checked;
 
-    /** @inheritDoc */
-    protected function setLabelPositionedAbove(): bool
-    {
-        return true; // unused
-    }
-
-    /**
-     * Set the checkable component check status.
-     *
-     * @param bool $checked
-     *
-     * @return $this
-     */
     public function checked(bool $checked = true): self
     {
         $this->checked = $checked;
@@ -31,15 +14,16 @@ abstract class CheckableAbstract extends FormAbstract
         return $this;
     }
 
-    /** @inheritDoc */
+    protected function setLabelPositionedAbove(): bool
+    {
+        return true; // unused
+    }
+
     protected function getComponentHtmlAttributes(): array
     {
         return array_merge(parent::getComponentHtmlAttributes(), $this->getChecked() ? ['checked' => 'checked'] : []);
     }
 
-    /**
-     * @return bool
-     */
     protected function getChecked(): bool
     {
         $old = old($this->getName());

--- a/src/Components/Form/Abstracts/CheckableAbstract.php
+++ b/src/Components/Form/Abstracts/CheckableAbstract.php
@@ -26,7 +26,7 @@ abstract class CheckableAbstract extends FormAbstract
 
     protected function getChecked(): bool
     {
-        $old = old($this->getName());
+        $old = old($this->convertArrayNameInNotation());
         if (isset($old)) {
             return $old;
         }

--- a/src/Components/Form/Abstracts/FormAbstract.php
+++ b/src/Components/Form/Abstracts/FormAbstract.php
@@ -45,9 +45,6 @@ abstract class FormAbstract extends ComponentAbstract
     /** @property bool $displayFailure */
     protected $displayFailure;
 
-    /**
-     * Form constructor.
-     */
     public function __construct()
     {
         parent::__construct();
@@ -218,7 +215,6 @@ abstract class FormAbstract extends ComponentAbstract
         return $this;
     }
 
-    /** @inheritDoc */
     protected function getValues(): array
     {
         return array_merge(parent::getValues(), $this->getParameters());
@@ -264,25 +260,16 @@ abstract class FormAbstract extends ComponentAbstract
         );
     }
 
-    /**
-     * @return \Illuminate\Database\Eloquent\Model|null
-     */
     protected function getModel(): ?Model
     {
         return $this->model;
     }
 
-    /**
-     * @return string
-     */
     protected function getName(): string
     {
         return Str::snake($this->name);
     }
 
-    /**
-     * @return string|null
-     */
     protected function getPrepend(): ?string
     {
         return $this->prepend;
@@ -295,9 +282,6 @@ abstract class FormAbstract extends ComponentAbstract
      */
     abstract protected function setPrepend(): ?string;
 
-    /**
-     * @return string|null
-     */
     protected function getAppend(): ?string
     {
         return $this->append;
@@ -310,9 +294,6 @@ abstract class FormAbstract extends ComponentAbstract
      */
     abstract protected function setAppend(): ?string;
 
-    /**
-     * @return string|null
-     */
     protected function getCaption(): ?string
     {
         return $this->caption;
@@ -325,17 +306,11 @@ abstract class FormAbstract extends ComponentAbstract
      */
     abstract protected function setCaption(): ?string;
 
-    /**
-     * @return string
-     */
     protected function getLabel(): string
     {
-        return $this->label ?? (string) __('validation.attributes.' . $this->getName());
+        return $this->label ?? (string) __('validation.attributes.' . $this->removeArrayCharactersFromName());
     }
 
-    /**
-     * @return bool
-     */
     protected function getLabelPositionedAbove(): bool
     {
         return $this->labelPositionedAbove;
@@ -353,24 +328,29 @@ abstract class FormAbstract extends ComponentAbstract
      */
     protected function getValue()
     {
-        $value = old($this->getName()) ?: $this->value;
+        $value = old($this->convertArrayNameInNotation()) ?: $this->value;
         // fallback for usage of closure with non multilingual fields
         $value = $value instanceof Closure ? $value(app()->getLocale()) : $value;
 
-        return $value ?? optional($this->getModel())->{$this->getName()};
+        return $value ?? optional($this->getModel())->{$this->convertArrayNameInNotation()};
     }
 
-    /**
-     * @return string|null
-     */
+    protected function convertArrayNameInNotation(string $notation = '.'): string
+    {
+        return str_replace(['[', ']'], [$notation, ''], $this->getName());
+    }
+
     protected function getPlaceholder(): ?string
     {
-        return $this->placeholder ?? ($this->getLabel() ?: (string) __('validation.attributes.' . $this->getName()));
+        return $this->placeholder
+            ?? ($this->getLabel() ?: (string) __('validation.attributes.' . $this->removeArrayCharactersFromName()));
     }
 
-    /**
-     * @return bool
-     */
+    protected function removeArrayCharactersFromName(): string
+    {
+        return strstr($this->getName(), '[', true) ?: $this->getName();
+    }
+
     protected function getDisplaySuccess(): bool
     {
         return $this->displaySuccess;
@@ -383,9 +363,6 @@ abstract class FormAbstract extends ComponentAbstract
      */
     abstract protected function setDisplaySuccess(): bool;
 
-    /**
-     * @return bool
-     */
     protected function getDisplayFailure(): bool
     {
         return $this->displayFailure;
@@ -398,9 +375,6 @@ abstract class FormAbstract extends ComponentAbstract
      */
     abstract protected function setDisplayFailure(): bool;
 
-    /**
-     * @return string|null
-     */
     protected function getValidationClass(): ?string
     {
         if (session()->has('errors')) {
@@ -412,20 +386,11 @@ abstract class FormAbstract extends ComponentAbstract
         return null;
     }
 
-    protected function convertArrayNameInNotation(string $notation = '.'): string
-    {
-        return str_replace(['[', ']'], [$notation, ''], $this->getName());
-    }
-
-    /**
-     * @return string|null
-     */
     protected function getErrorMessage(): ?string
     {
         return optional(session()->get('errors'))->first($this->convertArrayNameInNotation());
     }
 
-    /** @inheritDoc */
     protected function getComponentId(): string
     {
         return parent::getComponentId() ?? $this->getType() . '-' . Str::slug($this->convertArrayNameInNotation('-'));

--- a/src/Components/Form/Abstracts/FormAbstract.php
+++ b/src/Components/Form/Abstracts/FormAbstract.php
@@ -404,7 +404,7 @@ abstract class FormAbstract extends ComponentAbstract
     protected function getValidationClass(): ?string
     {
         if (session()->has('errors')) {
-            return session()->get('errors')->has($this->getName())
+            return session()->get('errors')->has($this->convertArrayNameInNotation())
                 ? ($this->getDisplayFailure() ? 'is-invalid' : null)
                 : ($this->getDisplaySuccess() ? 'is-valid' : null);
         }
@@ -412,17 +412,22 @@ abstract class FormAbstract extends ComponentAbstract
         return null;
     }
 
+    protected function convertArrayNameInNotation(string $notation = '.'): string
+    {
+        return str_replace(['[', ']'], [$notation, ''], $this->getName());
+    }
+
     /**
      * @return string|null
      */
     protected function getErrorMessage(): ?string
     {
-        return optional(session()->get('errors'))->first($this->getName());
+        return optional(session()->get('errors'))->first($this->convertArrayNameInNotation());
     }
 
     /** @inheritDoc */
     protected function getComponentId(): string
     {
-        return parent::getComponentId() ?? $this->getType() . '-' . Str::slug($this->getName());
+        return parent::getComponentId() ?? $this->getType() . '-' . Str::slug($this->convertArrayNameInNotation('-'));
     }
 }

--- a/src/Components/Form/Abstracts/RadioAbstract.php
+++ b/src/Components/Form/Abstracts/RadioAbstract.php
@@ -9,16 +9,13 @@ abstract class RadioAbstract extends CheckableAbstract
 {
     use RadioValidityChecks;
 
-    /** @inheritDoc */
     protected function getComponentId(): string
     {
         return $this->componentId
-            ?? $this->getType() . '-' . Str::slug($this->convertArrayNameInNotation('-')) . '-' . Str::slug($this->getValue());
+            ?? $this->getType() . '-' . Str::slug($this->convertArrayNameInNotation('-')) . '-'
+            . Str::slug($this->getValue());
     }
 
-    /**
-     * @return bool
-     */
     protected function getChecked(): bool
     {
         $old = old($this->getName());

--- a/src/Components/Form/Abstracts/RadioAbstract.php
+++ b/src/Components/Form/Abstracts/RadioAbstract.php
@@ -13,7 +13,7 @@ abstract class RadioAbstract extends CheckableAbstract
     protected function getComponentId(): string
     {
         return $this->componentId
-            ?? $this->getType() . '-' . Str::slug($this->getName()) . '-' . Str::slug($this->getValue());
+            ?? $this->getType() . '-' . Str::slug($this->convertArrayNameInNotation('-')) . '-' . Str::slug($this->getValue());
     }
 
     /**

--- a/src/Components/Form/Abstracts/SelectableAbstract.php
+++ b/src/Components/Form/Abstracts/SelectableAbstract.php
@@ -207,7 +207,7 @@ abstract class SelectableAbstract extends FormAbstract
      */
     protected function searchMultipleSelectedOptionFromOldValue(): ?array
     {
-        $oldValue = old($this->getName());
+        $oldValue = old($this->convertArrayNameInNotation());
         if ($oldValue) {
             $selectedMultipleOptions = Arr::where($this->options, function ($option) use ($oldValue) {
                 return in_array($option[$this->optionValueField], $oldValue);
@@ -288,7 +288,7 @@ abstract class SelectableAbstract extends FormAbstract
      */
     protected function searchSelectedOptionFromOldValue(): ?array
     {
-        $oldValue = old($this->getName());
+        $oldValue = old($this->convertArrayNameInNotation());
         if ($oldValue) {
             $selectedOption = Arr::where($this->options, function ($option) use ($oldValue) {
                 return $option[$this->optionValueField] === $oldValue;

--- a/src/Components/Form/Abstracts/UploadableAbstract.php
+++ b/src/Components/Form/Abstracts/UploadableAbstract.php
@@ -28,9 +28,6 @@ abstract class UploadableAbstract extends FormAbstract
      */
     protected $removeCheckboxLabel;
 
-    /**
-     * File constructor.
-     */
     public function __construct()
     {
         parent::__construct();
@@ -67,7 +64,6 @@ abstract class UploadableAbstract extends FormAbstract
         return $this;
     }
 
-    /** @inheritDoc */
     protected function getValues(): array
     {
         return array_merge(parent::getValues(), [
@@ -77,11 +73,6 @@ abstract class UploadableAbstract extends FormAbstract
         ]);
     }
 
-    /**
-     * Get the uploadedFile HTML.
-     *
-     * @return HtmlString
-     */
     protected function getUploadedFileHtml(): HtmlString
     {
         $uploadedFileHtml = '';
@@ -97,24 +88,13 @@ abstract class UploadableAbstract extends FormAbstract
         return new HtmlString($uploadedFileHtml);
     }
 
-    /**
-     * @return bool
-     */
     protected function getShowRemoveCheckbox(): bool
     {
         return $this->showRemoveCheckbox;
     }
 
-    /**
-     * @return bool
-     */
     abstract protected function setShowRemoveCheckbox(): bool;
 
-    /**
-     * @param string|null $label
-     *
-     * @return string
-     */
     protected function getRemoveCheckboxLabel(?string $label): string
     {
         $defaultRemoveCheckboxLabel = ((string) __('Remove')) . ($label ? ' ' . strtolower($label) : '');
@@ -122,7 +102,6 @@ abstract class UploadableAbstract extends FormAbstract
         return $this->removeCheckboxLabel ?? $defaultRemoveCheckboxLabel;
     }
 
-    /** @inheritDoc */
     protected function getPlaceholder(): ?string
     {
         return $this->placeholder ?? (string) __('No file selected.');

--- a/tests/Unit/Form/Abstracts/InputCheckableTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/InputCheckableTestAbstract.php
@@ -165,6 +165,21 @@ abstract class InputCheckableTestAbstract extends InputTestAbstract
         $this->assertStringContainsString('checked="checked', $html);
     }
 
+    public function testOldArrayValue()
+    {
+        $oldValue = true;
+        $value = false;
+        $this->app['router']->get('test', [
+            'middleware' => 'web', 'uses' => function () use ($oldValue) {
+                $request = request()->merge(['active' => [0 => $oldValue]]);
+                $request->flash();
+            },
+        ]);
+        $this->call('GET', 'test');
+        $html = $this->getComponent()->name('active[0]')->value($value)->toHtml();
+        $this->assertStringContainsString('checked="checked', $html);
+    }
+
     public function testOldValueNotChecked()
     {
         $oldValue = false;
@@ -213,6 +228,16 @@ abstract class InputCheckableTestAbstract extends InputTestAbstract
         $this->markTestSkipped();
     }
 
+    public function testDefaultPlaceholder()
+    {
+        $this->markTestSkipped();
+    }
+
+    public function testDefaultPlaceholderWithArrayName()
+    {
+        $this->markTestSkipped();
+    }
+
     public function testSetPlaceholder()
     {
         $this->markTestSkipped();
@@ -228,7 +253,7 @@ abstract class InputCheckableTestAbstract extends InputTestAbstract
         $this->markTestSkipped();
     }
 
-    public function testNoPlaceholder()
+    public function testNoPlaceholderWithLabel()
     {
         $this->markTestSkipped();
     }

--- a/tests/Unit/Form/Abstracts/InputFileTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/InputFileTestAbstract.php
@@ -89,6 +89,40 @@ abstract class InputFileTestAbstract extends InputTestAbstract
             . '-name">' . $value . '</label>', $html);
     }
 
+    public function testOldArrayValue()
+    {
+        $oldValue = 'old-value';
+        $value = 'custom-value';
+        $this->app['router']->get('test', [
+            'middleware' => 'web', 'uses' => function () use ($oldValue) {
+                $request = request()->merge(['name' => [0 => $oldValue]]);
+                $request->flash();
+            },
+        ]);
+        $this->call('GET', 'test');
+        $html = $this->getComponent()->name('name[0]')->value($value)->toHtml();
+        $this->assertStringContainsString('<label class="custom-file-label" for="' . $this->getComponentType()
+            . '-name-0">' . $oldValue . '</label>', $html);
+        $this->assertStringNotContainsString('<label class="custom-file-label" for="' . $this->getComponentType()
+            . '-name-0">' . $value . '</label>', $html);
+    }
+
+    public function testDefaultPlaceholder()
+    {
+        $html = $this->getComponent()->name('name')->toHtml();
+        $this->assertStringContainsString('custom-file-label', $html);
+        $this->assertStringContainsString('<label class="custom-file-label" for="' . $this->getComponentType()
+            . '-name">' . __('No file selected.') . '</label>', $html);
+    }
+
+    public function testDefaultPlaceholderWithArrayName()
+    {
+        $html = $this->getComponent()->name('name[0]')->toHtml();
+        $this->assertStringContainsString('custom-file-label', $html);
+        $this->assertStringContainsString('<label class="custom-file-label" for="' . $this->getComponentType()
+            . '-name-0">' . __('No file selected.') . '</label>', $html);
+    }
+
     public function testSetPlaceholder()
     {
         $placeholder = 'custom-placeholder';
@@ -107,6 +141,16 @@ abstract class InputFileTestAbstract extends InputTestAbstract
             . '-name">' . $placeholder . '</label>', $html);
     }
 
+    public function testNoPlaceholderWithLabel()
+    {
+        $label = 'custom-label';
+        $html = $this->getComponent()->name('name')->label($label)->toHtml();
+        $this->assertStringContainsString('<label class="custom-file-label" for="' . $this->getComponentType()
+            . '-name">' . __('No file selected.') . '</label>', $html);
+        $this->assertStringNotContainsString('<label class="custom-file-label" for="' . $this->getComponentType()
+            . '-name">' . $label . '</label>', $html);
+    }
+
     public function testNoPlaceholderWithNoLabel()
     {
         $html = $this->getComponent()->name('name')->label(false)->toHtml();
@@ -115,13 +159,6 @@ abstract class InputFileTestAbstract extends InputTestAbstract
             . '-name">' . __('No file selected.') . '</label>', $html);
     }
 
-    public function testNoPlaceholder()
-    {
-        $html = $this->getComponent()->name('name')->toHtml();
-        $this->assertStringContainsString('custom-file-label', $html);
-        $this->assertStringContainsString('<label class="custom-file-label" for="' . $this->getComponentType()
-            . '-name">' . __('No file selected.') . '</label>', $html);
-    }
 
     public function testHidePlaceholder()
     {

--- a/tests/Unit/Form/Abstracts/InputRadioTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/InputRadioTestAbstract.php
@@ -236,8 +236,15 @@ abstract class InputRadioTestAbstract extends InputTestAbstract
     public function testDefaultComponentId()
     {
         $html = $this->getComponent()->name('name')->toHtml();
-        $this->assertStringContainsString('<input id="' . $this->getComponentType() . '-name-value"', $html);
         $this->assertStringContainsString(' for="' . $this->getComponentType() . '-name-value"', $html);
+        $this->assertStringContainsString('<input id="' . $this->getComponentType() . '-name-value"', $html);
+    }
+
+    public function testDefaultComponentIdWithArrayName()
+    {
+        $html = $this->getComponent()->name('name[0]')->toHtml();
+        $this->assertStringContainsString(' for="' . $this->getComponentType() . '-name-0-value"', $html);
+        $this->assertStringContainsString('<input id="' . $this->getComponentType() . '-name-0-value"', $html);
     }
 
     public function testSetCustomContainerClasses()

--- a/tests/Unit/Form/Abstracts/InputRadioTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/InputRadioTestAbstract.php
@@ -203,6 +203,16 @@ abstract class InputRadioTestAbstract extends InputTestAbstract
         $this->markTestSkipped();
     }
 
+    public function testDefaultPlaceholder()
+    {
+        $this->markTestSkipped();
+    }
+
+    public function testDefaultPlaceholderWithArrayName()
+    {
+        $this->markTestSkipped();
+    }
+
     public function testSetPlaceholder()
     {
         $this->markTestSkipped();
@@ -218,7 +228,7 @@ abstract class InputRadioTestAbstract extends InputTestAbstract
         $this->markTestSkipped();
     }
 
-    public function testNoPlaceholder()
+    public function testNoPlaceholderWithLabel()
     {
         $this->markTestSkipped();
     }

--- a/tests/Unit/Form/Abstracts/InputTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/InputTestAbstract.php
@@ -345,6 +345,16 @@ abstract class InputTestAbstract extends BootstrapComponentsTestCase
         $this->assertStringNotContainsString($errors->first('name'), $html);
     }
 
+    public function testDisplayFailureWithArrayName()
+    {
+        $errors = app(MessageBag::class)->add('name.0', 'Dummy error message.');
+        session()->put('errors', $errors);
+        $html = $this->getComponent()->name('name[0]')->render(compact('errors'));
+        $this->assertStringContainsString('is-invalid', $html);
+        $this->assertStringContainsString('<div class="invalid-feedback d-block">', $html);
+        $this->assertStringContainsString($errors->first('name'), $html);
+    }
+
     public function testSetNoContainerId()
     {
         $html = $this->getComponent()->name('name')->toHtml();
@@ -363,6 +373,13 @@ abstract class InputTestAbstract extends BootstrapComponentsTestCase
         $html = $this->getComponent()->name('name')->toHtml();
         $this->assertStringContainsString(' for="' . $this->getComponentType() . '-name"', $html);
         $this->assertStringContainsString('<input id="' . $this->getComponentType() . '-name"', $html);
+    }
+
+    public function testDefaultComponentIdWithArrayName()
+    {
+        $html = $this->getComponent()->name('name[0]')->toHtml();
+        $this->assertStringContainsString(' for="' . $this->getComponentType() . '-name-0"', $html);
+        $this->assertStringContainsString('<input id="' . $this->getComponentType() . '-name-0"', $html);
     }
 
     public function testSetComponentId()

--- a/tests/Unit/Form/Abstracts/InputTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/InputTestAbstract.php
@@ -203,6 +203,22 @@ abstract class InputTestAbstract extends BootstrapComponentsTestCase
         $this->assertStringNotContainsString(' value="' . $value . '"', $html);
     }
 
+    public function testOldArrayValue()
+    {
+        $oldValue = 'old-value';
+        $value = 'custom-value';
+        $this->app['router']->get('test', [
+            'middleware' => 'web', 'uses' => function () use ($oldValue) {
+                $request = request()->merge(['name' => [0 => $oldValue]]);
+                $request->flash();
+            },
+        ]);
+        $this->call('GET', 'test');
+        $html = $this->getComponent()->name('name[0]')->value($value)->toHtml();
+        $this->assertStringContainsString(' value="' . $oldValue . '"', $html);
+        $this->assertStringNotContainsString(' value="' . $value . '"', $html);
+    }
+
     public function testSetLabel()
     {
         $label = 'custom-label';
@@ -255,6 +271,18 @@ abstract class InputTestAbstract extends BootstrapComponentsTestCase
         $this->assertLessThan($inputPosition, $labelPosition);
     }
 
+    public function testDefaultPlaceholder()
+    {
+        $html = $this->getComponent()->name('name')->toHtml();
+        $this->assertStringContainsString(' placeholder="validation.attributes.name"', $html);
+    }
+
+    public function testDefaultPlaceholderWithArrayName()
+    {
+        $html = $this->getComponent()->name('name[0]')->toHtml();
+        $this->assertStringContainsString(' placeholder="validation.attributes.name"', $html);
+    }
+
     public function testSetPlaceholder()
     {
         $placeholder = 'custom-placeholder';
@@ -271,10 +299,12 @@ abstract class InputTestAbstract extends BootstrapComponentsTestCase
         $this->assertStringNotContainsString(' placeholder="' . $label . '"', $html);
     }
 
-    public function testNoPlaceholder()
+    public function testNoPlaceholderWithLabel()
     {
-        $html = $this->getComponent()->name('name')->toHtml();
-        $this->assertStringContainsString(' placeholder="validation.attributes.name"', $html);
+        $label = 'custom-label';
+        $html = $this->getComponent()->name('name')->label($label)->toHtml();
+        $this->assertStringContainsString(' placeholder="' . $label . '"', $html);
+        $this->assertStringNotContainsString(' placeholder="validation.attributes.name"', $html);
     }
 
     public function testNoPlaceholderWithNoLabel()

--- a/tests/Unit/Form/Abstracts/SelectTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/SelectTestAbstract.php
@@ -575,6 +575,13 @@ abstract class SelectTestAbstract extends InputTestAbstract
         $this->assertStringContainsString('<select id="' . $this->getComponentType() . '-name"', $html);
     }
 
+    public function testDefaultComponentIdWithArrayName()
+    {
+        $html = $this->getComponent()->name('name[0]')->toHtml();
+        $this->assertStringContainsString(' for="' . $this->getComponentType() . '-name-0"', $html);
+        $this->assertStringContainsString('<select id="' . $this->getComponentType() . '-name-0"', $html);
+    }
+
     public function testSetComponentId()
     {
         $customComponentId = 'test-custom-component-id';

--- a/tests/Unit/Form/Abstracts/TemporalTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/TemporalTestAbstract.php
@@ -121,8 +121,8 @@ abstract class TemporalTestAbstract extends InputTestAbstract
 
     public function testOldValue()
     {
-        $oldValue = $this->faker->dateTime->format('Y-m-d');
-        $value = $this->faker->dateTime->format('Y-m-d');
+        $oldValue = $this->faker->dateTime->format($this->getFormat());
+        $value = $this->faker->dateTime->format($this->getFormat());
         $this->app['router']->get('test', [
             'middleware' => 'web', 'uses' => function () use ($oldValue) {
                 $request = request()->merge(['name' => $oldValue]);
@@ -131,6 +131,22 @@ abstract class TemporalTestAbstract extends InputTestAbstract
         ]);
         $this->call('GET', 'test');
         $html = $this->getComponent()->name('name')->value($value)->toHtml();
+        $this->assertStringContainsString(' value="' . $oldValue . '"', $html);
+        $this->assertStringNotContainsString(' value="' . $value . '"', $html);
+    }
+
+    public function testOldArrayValue()
+    {
+        $oldValue = $this->faker->dateTime->format($this->getFormat());
+        $value = $this->faker->dateTime->format($this->getFormat());
+        $this->app['router']->get('test', [
+            'middleware' => 'web', 'uses' => function () use ($oldValue) {
+                $request = request()->merge(['name' => [0 => $oldValue]]);
+                $request->flash();
+            },
+        ]);
+        $this->call('GET', 'test');
+        $html = $this->getComponent()->name('name[0]')->value($value)->toHtml();
         $this->assertStringContainsString(' value="' . $oldValue . '"', $html);
         $this->assertStringNotContainsString(' value="' . $value . '"', $html);
     }

--- a/tests/Unit/Form/Abstracts/TextareaTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/TextareaTestAbstract.php
@@ -99,6 +99,13 @@ abstract class TextareaTestAbstract extends InputMultilingualTestAbstract
         $this->assertStringContainsString('<textarea id="' . $this->getComponentType() . '-name"', $html);
     }
 
+    public function testDefaultComponentIdWithArrayName()
+    {
+        $html = $this->getComponent()->name('name[0]')->toHtml();
+        $this->assertStringContainsString(' for="' . $this->getComponentType() . '-name-0"', $html);
+        $this->assertStringContainsString('<textarea id="' . $this->getComponentType() . '-name-0"', $html);
+    }
+
     public function testSetComponentId()
     {
         $customComponentId = 'custom-component-id';

--- a/tests/Unit/Form/Abstracts/TextareaTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/TextareaTestAbstract.php
@@ -68,6 +68,22 @@ abstract class TextareaTestAbstract extends InputMultilingualTestAbstract
         $this->assertStringNotContainsString($value . '</textarea>', $html);
     }
 
+    public function testOldArrayValue()
+    {
+        $oldValue = 'old-value';
+        $value = 'custom-value';
+        $this->app['router']->get('test', [
+            'middleware' => 'web', 'uses' => function () use ($oldValue) {
+                $request = request()->merge(['name' => [0 => $oldValue]]);
+                $request->flash();
+            },
+        ]);
+        $this->call('GET', 'test');
+        $html = $this->getComponent()->name('name[0]')->value($value)->toHtml();
+        $this->assertStringContainsString($oldValue . '</textarea>', $html);
+        $this->assertStringNotContainsString($value . '</textarea>', $html);
+    }
+
     public function testSetCustomLabelPositionedAbove()
     {
         config()->set(


### PR DESCRIPTION
* Fixed the form components pre-filling when defining an array name (eg. `name[0]`).
* Fixed the placeholder generation when defining an array name (eg. `name[0]`).