### PR TITLE
2.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.1.9](https://github.com/Okipa/laravel-bootstrap-components/compare/2.1.8...2.1.9)
+
+2020-05-25
+
+* Fixed the `Select` component old value analysis: the select value compared against the old one is now being converted to string during the process in order to get a correct comparison with values transmitted from the HTTP request (which are always strings).
+
 ## [2.1.8](https://github.com/Okipa/laravel-bootstrap-components/compare/2.1.7...2.1.8)
 
 2020-05-15

--- a/src/Components/Form/Abstracts/SelectableAbstract.php
+++ b/src/Components/Form/Abstracts/SelectableAbstract.php
@@ -291,7 +291,7 @@ abstract class SelectableAbstract extends FormAbstract
         $oldValue = old($this->convertArrayNameInNotation());
         if ($oldValue) {
             $selectedOption = Arr::where($this->options, function ($option) use ($oldValue) {
-                return $option[$this->optionValueField] === $oldValue;
+                return (string) $option[$this->optionValueField] === $oldValue;
             });
             if (! empty($selectedOption)) {
                 return $selectedOption;

--- a/tests/Unit/Form/Abstracts/InputCheckableTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/InputCheckableTestAbstract.php
@@ -156,7 +156,7 @@ abstract class InputCheckableTestAbstract extends InputTestAbstract
         $value = false;
         $this->app['router']->get('test', [
             'middleware' => 'web', 'uses' => function () use ($oldValue) {
-                $request = request()->merge(['active' => $oldValue]);
+                $request = request()->merge(['active' => (string) $oldValue]);
                 $request->flash();
             },
         ]);
@@ -171,7 +171,7 @@ abstract class InputCheckableTestAbstract extends InputTestAbstract
         $value = false;
         $this->app['router']->get('test', [
             'middleware' => 'web', 'uses' => function () use ($oldValue) {
-                $request = request()->merge(['active' => [0 => $oldValue]]);
+                $request = request()->merge(['active' => [0 => (string) $oldValue]]);
                 $request->flash();
             },
         ]);
@@ -186,7 +186,7 @@ abstract class InputCheckableTestAbstract extends InputTestAbstract
         $value = true;
         $this->app['router']->get('test', [
             'middleware' => 'web', 'uses' => function () use ($oldValue) {
-                $request = request()->merge(['active' => $oldValue]);
+                $request = request()->merge(['active' => (string) $oldValue]);
                 $request->flash();
             },
         ]);

--- a/tests/Unit/Form/Abstracts/SelectTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/SelectTestAbstract.php
@@ -236,7 +236,7 @@ abstract class SelectTestAbstract extends InputTestAbstract
         $old = $users->get(2);
         $this->app['router']->get('test', [
             'middleware' => 'web', 'uses' => function () use ($old) {
-                $request = request()->merge(['name' => $old->id]);
+                $request = request()->merge(['name' => (string) $old->id]);
                 $request->flash();
             },
         ]);
@@ -269,7 +269,7 @@ abstract class SelectTestAbstract extends InputTestAbstract
         $old = $users->get(2);
         $this->app['router']->get('test', [
             'middleware' => 'web', 'uses' => function () use ($old) {
-                $request = request()->merge(['name' => [0 => $old->id]]);
+                $request = request()->merge(['name' => [0 => (string) $old->id]]);
                 $request->flash();
             },
         ]);
@@ -497,7 +497,9 @@ abstract class SelectTestAbstract extends InputTestAbstract
     {
         $user = $this->createUniqueUser();
         $companies = $this->createMultipleCompanies(6);
-        $chunk = $companies->pluck('id')->chunk(2)->toArray();
+        $chunk = $companies->pluck('id')->map(function ($id) {
+            return (string) $id;
+        })->chunk(2)->toArray();
         $user->companies = $chunk[0];
         $selectedCompanies = $chunk[1];
         $oldCompanies = $chunk[2];
@@ -533,7 +535,9 @@ abstract class SelectTestAbstract extends InputTestAbstract
     {
         $user = $this->createUniqueUser();
         $companies = $this->createMultipleCompanies(6);
-        $chunk = $companies->pluck('id')->chunk(2)->toArray();
+        $chunk = $companies->pluck('id')->map(function ($id) {
+            return (string) $id;
+        })->chunk(2)->toArray();
         $user->companies = $chunk[0];
         $selectedCompanies = $chunk[1];
         $oldCompanies = $chunk[2];


### PR DESCRIPTION
* Fixed the `Select` component old value analysis: the select value compared against the old one is now being converted to string during the process in order to get a correct comparison with values transmitted from the HTTP request (which are always strings).