### PR TITLE
2.1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.1.12](https://github.com/Okipa/laravel-bootstrap-components/compare/2.1.11...2.1.12)
+
+2020-07-07
+
+* Fixed wrong error message formatting for multilingual components when an input name contains several words (eg. `last_name`).
+
 ## [2.1.11](https://github.com/Okipa/laravel-bootstrap-components/compare/2.1.10...2.1.11)
 
 2020-06-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 2020-07-07
 
-* Fixed wrong error message formatting for multilingual components when an input name contains several words (eg. `last_name`).
+* Fixed wrong error message formatting for multilingual components when an input name contains several words.
+  * Eg. with a `last_name` input name => The error `The last name.en field is required.` will now display like following: `The Last name (EN) field is required.` (supposing you have translated the `last_name` field in the `validation.attributes`).
 
 ## [2.1.11](https://github.com/Okipa/laravel-bootstrap-components/compare/2.1.10...2.1.11)
 

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
             "vendor/bin/phpcbf",
             "vendor/bin/phpcs",
             "vendor/bin/phpmd config,src text phpmd.xml",
-            "vendor/bin/phpstan analyse",
+            "vendor/bin/phpstan analyse --error-format=table --memory-limit=2048M",
             "vendor/bin/phpunit"
         ]
     },

--- a/src/Components/Form/Abstracts/MultilingualAbstract.php
+++ b/src/Components/Form/Abstracts/MultilingualAbstract.php
@@ -183,7 +183,7 @@ abstract class MultilingualAbstract extends FormAbstract
     {
         $label = parent::getLabel();
 
-        return $label ? $label . ' (' . strtoupper($locale) . ')' : null;
+        return $label ? $label . ' (' . mb_strtoupper($locale) . ')' : null;
     }
 
     /**
@@ -214,7 +214,7 @@ abstract class MultilingualAbstract extends FormAbstract
     {
         $placeholder = parent::getPlaceholder();
 
-        return $placeholder ? $placeholder . ' (' . strtoupper($locale) . ')' : null;
+        return $placeholder ? $placeholder . ' (' . mb_strtoupper($locale) . ')' : null;
     }
 
     /**

--- a/src/Components/Form/Abstracts/UploadableAbstract.php
+++ b/src/Components/Form/Abstracts/UploadableAbstract.php
@@ -98,7 +98,7 @@ abstract class UploadableAbstract extends FormAbstract
 
     protected function getRemoveCheckboxLabel(?string $label): string
     {
-        $defaultRemoveCheckboxLabel = ((string) __('Remove')) . ($label ? ' ' . strtolower($label) : '');
+        $defaultRemoveCheckboxLabel = ((string) __('Remove')) . ($label ? ' ' . mb_strtolower($label) : '');
 
         return $this->removeCheckboxLabel ?? $defaultRemoveCheckboxLabel;
     }

--- a/src/Components/Form/Multilingual/Resolver.php
+++ b/src/Components/Form/Multilingual/Resolver.php
@@ -41,6 +41,7 @@ class Resolver
      *
      * @param string $name
      * @param string $locale
+     *
      * @return string|null
      */
     public function resolveLocalizedOldValue(string $name, string $locale): ?string
@@ -74,6 +75,7 @@ class Resolver
     {
         $errorMessageBagKey = $this->resolveErrorMessageBagKey($name, $locale);
         $errorMessage = optional(session()->get('errors'))->first($errorMessageBagKey);
+        $errorMessage = $this->undoInputNameLaravelUnderscoreRemovalInErrorMessage($name, $errorMessage);
 
         return $errorMessage
             ? str_replace(
@@ -95,5 +97,15 @@ class Resolver
     public function resolveErrorMessageBagKey(string $name, string $locale): string
     {
         return $name . '.' . $locale;
+    }
+
+    protected function undoInputNameLaravelUnderscoreRemovalInErrorMessage(string $name, ?string $errorMessage): ?string
+    {
+        if (! $errorMessage) {
+            return null;
+        }
+        $inputNameWithoutUnderscore = str_replace('_', ' ', $name);
+
+        return str_replace($inputNameWithoutUnderscore, $name, $errorMessage);
     }
 }

--- a/src/Components/Form/Multilingual/Resolver.php
+++ b/src/Components/Form/Multilingual/Resolver.php
@@ -75,7 +75,7 @@ class Resolver
     {
         $errorMessageBagKey = $this->resolveErrorMessageBagKey($name, $locale);
         $errorMessage = optional(session()->get('errors'))->first($errorMessageBagKey);
-        $errorMessage = $this->undoInputNameLaravelUnderscoreRemovalInErrorMessage($name, $errorMessage);
+        $errorMessage = $this->undoInputNameLaravelUnderscoreRemovalInErrorMessage($name, $locale, $errorMessage);
 
         return $errorMessage
             ? str_replace(
@@ -99,8 +99,19 @@ class Resolver
         return $name . '.' . $locale;
     }
 
-    protected function undoInputNameLaravelUnderscoreRemovalInErrorMessage(string $name, ?string $errorMessage): ?string
-    {
+    /**
+     * @param string $name
+     * @param string $locale
+     * @param string|null $errorMessage
+     *
+     * @return string|null
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    protected function undoInputNameLaravelUnderscoreRemovalInErrorMessage(
+        string $name,
+        string $locale,
+        ?string $errorMessage
+    ): ?string {
         if (! $errorMessage) {
             return null;
         }

--- a/tests/Dummy/Resolver.php
+++ b/tests/Dummy/Resolver.php
@@ -6,29 +6,37 @@ use Illuminate\Database\Eloquent\Model;
 
 class Resolver extends \Okipa\LaravelBootstrapComponents\Components\Form\Multilingual\Resolver
 {
-    /** @inheritDoc */
     protected $locales = ['en', 'de'];
 
-    /** @inheritDoc */
-    public function resolveLocalizedName(string $name, string $locale): string
-    {
-        return $name . '_' . $locale;
-    }
-
-    /** @inheritDoc */
     public function resolveLocalizedOldValue(string $name, string $locale): ?string
     {
         return old($name . '_' . $locale);
     }
 
-    /** @inheritDoc */
     public function resolveLocalizedModelValue(string $name, string $locale, ?Model $model): ?string
     {
         return optional($model)->{$name . '_' . $locale};
     }
 
-    /** @inheritDoc */
     public function resolveErrorMessageBagKey(string $name, string $locale): string
+    {
+        return $name . '_' . $locale;
+    }
+
+    protected function undoInputNameLaravelUnderscoreRemovalInErrorMessage(
+        string $name,
+        string $locale,
+        ?string $errorMessage
+    ): ?string {
+        if (! $errorMessage) {
+            return null;
+        }
+        $inputNameWithoutUnderscore = str_replace('_', ' ', $this->resolveLocalizedName($name, $locale));
+
+        return str_replace($inputNameWithoutUnderscore, $this->resolveLocalizedName($name, $locale), $errorMessage);
+    }
+
+    public function resolveLocalizedName(string $name, string $locale): string
     {
         return $name . '_' . $locale;
     }

--- a/tests/Unit/Form/Abstracts/InputMultilingualTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/InputMultilingualTestAbstract.php
@@ -248,6 +248,35 @@ abstract class InputMultilingualTestAbstract extends InputTestAbstract
         );
     }
 
+    public function testLocalizedErrorMessageWithSeveralWords()
+    {
+        $locales = ['fr', 'en'];
+        $errors = app(MessageBag::class);
+        $errors->add('last_name.fr', 'Dummy last name.fr error message.');
+        session()->put('errors', $errors);
+        $html = $this->getComponent()
+            ->name('last_name')
+            ->locales($locales)
+            ->displayFailure()
+            ->render(compact('errors'));
+        $this->assertStringContainsString(
+            'id="' . $this->getComponentType() . '-last-name-fr" class="component form-control is-invalid"',
+            $html
+        );
+        $this->assertStringContainsString(
+            'Dummy ' . _('validation.attributes.last_name') . ' (FR) error message.',
+            $html
+        );
+        $this->assertStringNotContainsString(
+            'id="' . $this->getComponentType() . '-last-name-en" class="component form-control is-invalid"',
+            $html
+        );
+        $this->assertStringNotContainsString(
+            'Dummy ' . _('validation.attributes.last_name') . ' (EN) error message.',
+            $html
+        );
+    }
+
     public function testLocalizedErrorMessageFromCustomMultilingualResolver()
     {
         config()->set('bootstrap-components.form.multilingualResolver', Resolver::class);

--- a/tests/Unit/Form/Abstracts/InputMultilingualTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/InputMultilingualTestAbstract.php
@@ -185,10 +185,10 @@ abstract class InputMultilingualTestAbstract extends InputTestAbstract
         foreach ($locales as $locale) {
             $this->assertStringContainsString(
                 '<label for="' . $this->getComponentType() . '-name-' . $locale . '">' . $label . ' ('
-                . strtoupper($locale) . ')</label>',
+                . mb_strtoupper($locale) . ')</label>',
                 $html
             );
-            $this->assertStringContainsString(' placeholder="' . $label . ' (' . strtoupper($locale) . ')"', $html);
+            $this->assertStringContainsString(' placeholder="' . $label . ' (' . mb_strtoupper($locale) . ')"', $html);
         }
     }
 
@@ -199,7 +199,7 @@ abstract class InputMultilingualTestAbstract extends InputTestAbstract
         $html = $this->getComponent()->name('name')->placeholder($placeholder)->locales($locales)->toHtml();
         foreach ($locales as $locale) {
             $this->assertStringContainsString(
-                ' placeholder="' . $placeholder . ' (' . strtoupper($locale) . ')"',
+                ' placeholder="' . $placeholder . ' (' . mb_strtoupper($locale) . ')"',
                 $html
             );
         }
@@ -253,6 +253,36 @@ abstract class InputMultilingualTestAbstract extends InputTestAbstract
         $locales = ['fr', 'en'];
         $errors = app(MessageBag::class);
         $errors->add('last_name.fr', 'Dummy last name.fr error message.');
+        session()->put('errors', $errors);
+        $html = $this->getComponent()
+            ->name('last_name')
+            ->locales($locales)
+            ->displayFailure()
+            ->render(compact('errors'));
+        $this->assertStringContainsString(
+            'id="' . $this->getComponentType() . '-last-name-fr" class="component form-control is-invalid"',
+            $html
+        );
+        $this->assertStringContainsString(
+            'Dummy ' . _('validation.attributes.last_name') . ' (FR) error message.',
+            $html
+        );
+        $this->assertStringNotContainsString(
+            'id="' . $this->getComponentType() . '-last-name-en" class="component form-control is-invalid"',
+            $html
+        );
+        $this->assertStringNotContainsString(
+            'Dummy ' . _('validation.attributes.last_name') . ' (EN) error message.',
+            $html
+        );
+    }
+
+    public function testLocalizedErrorMessageWithSeveralWordsAndCustomMultilingualResolver()
+    {
+        config()->set('bootstrap-components.form.multilingualResolver', Resolver::class);
+        $locales = ['fr', 'en'];
+        $errors = app(MessageBag::class);
+        $errors->add('last_name_fr', 'Dummy last name fr error message.');
         session()->put('errors', $errors);
         $html = $this->getComponent()
             ->name('last_name')


### PR DESCRIPTION
* Fixed wrong error message formatting for multilingual components when an input name contains several words.
  * Eg. with a `last_name` input name => The error `The last name.en field is required.` will now display like following: `The Last name (EN) field is required.` (supposing you have translated the `last_name` field in the `validation.attributes`).