### PR TITLE
2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 2020-07-10
 
-* Added the possibility to use a closure in the `prepend` and `append` methods of the [multilingual components](docs/api/types.md#multilingualabstract) in order to translate rendered prepended or appended HTML.
+* Added the possibility to use a closure as argument for the `prepend` and `append` methods of the [multilingual components](docs/api/types.md#multilingualabstract), in order to translate rendered prepended or appended HTML.
 
 ## [2.1.12](https://github.com/Okipa/laravel-bootstrap-components/compare/2.1.11...2.1.12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.2.0](https://github.com/Okipa/laravel-bootstrap-components/compare/2.1.12...2.2.0)
+
+2020-07-10
+
+* Added the possibility to use a closure in the `prepend` and `append` methods of the [multilingual components](docs/api/types.md#multilingualabstract) in order to translate rendered prepended or appended HTML.
+
 ## [2.1.12](https://github.com/Okipa/laravel-bootstrap-components/compare/2.1.11...2.1.12)
 
 2020-07-07

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -94,14 +94,14 @@
 | Signature | Required | Description |
 |---|---|---|
 | locales(array $locales): self | No | Set the component input language locales to handle. |
+| value(Closure $value): self | No | Set the component input value by returning it from this closure result : `->value(function(string $locale){})`. |
 | prepend(Closure $prepend): self | No | Set the component prepended HTML by returning it from this closure result : `->prepend(function(string $locale){})`. |
 | append(Closure $append): self | No | Set the component appended HTML by returning it from this closure result : `->append(function(string $locale){})`. |
-| value(Closure $value): self | No | Set the component input value by returning it from this closure result : `->value(function(string $locale){})`. |
 
 **Notes**
 
-* You will still be able to use the `prepend`, `append` and `value` methods as for a simple `FormAbstract` component if you wish to. Closure usage is an extra behaviour, which is here to allow you to display translated content.
-* A security fallback has been implemented in order to allow you to keep the Closure behaviour for the `prepend`, `append` and `value` methods, even if your component is not multilingual anymore. The `$locale` attribute will take the value of the current locale.
+* You will still be able to use the `value`, `prepend` and `append` methods as for a simple `FormAbstract` component if you wish to. Closure usage is an extra behaviour, which is here to allow you to display translated content.
+* A security fallback has been implemented in order to allow you to keep the Closure behaviour for the `value`, `prepend` and `append` methods, even if your component is not multilingual anymore. The `$locale` attribute will take the value of the current locale.
 * Each multilingual form component will behave as a monolingual form component as long as the `->locales()` method is not being used or as long as only one locale is declared.
 * The use of the `->locales()` method will replicate the component for each locale keys you declared.
   * For example, if you declare the `fr` and `en` locale keys for a text input component with the `title` attribute, you will get two `Title (FR)` and `Title (EN)` generated text input components.
@@ -120,15 +120,15 @@
 <MultilingualAbstract>
     // inherits FormAbstract methods
     ->locales(['fr', 'en'])
+    ->value(function(string $locale){
+        return $name[$locale];
+    });
     ->prepend(function(string $locale){
         return 'prepend-' . $locale;
     })
     ->append(function(string $locale){
         return 'append-' . $locale;
     }) 
-    ->value(function(string $locale){
-        return $name[$locale];
-    });
 ```
 
 **Components**

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -102,7 +102,7 @@
 
 * You will still be able to use the `value`, `prepend` and `append` methods as for a simple `FormAbstract` component if you wish to. Closure usage is an extra behaviour, which is here to allow you to display translated content.
 * A security fallback has been implemented in order to allow you to keep the Closure behaviour for the `value`, `prepend` and `append` methods, even if your component is not multilingual anymore. The `$locale` attribute will take the value of the current locale.
-* Each multilingual form component will behave as a monolingual form component as long as the `->locales()` method is not being used or as long as only one locale is declared.
+* Each multilingual form component will behave as a monolingual form component as long as the `->locales()` method is not being used or as long as only one locale is being declared.
 * The use of the `->locales()` method will replicate the component for each locale keys you declared.
   * For example, if you declare the `fr` and `en` locale keys for a text input component with the `title` attribute, you will get two `Title (FR)` and `Title (EN)` generated text input components.
 * Each multilingual component provides an extra `data-locale="<locale>"` attribute to help with eventual javascript treatments.

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -119,8 +119,16 @@
 ```php
 <MultilingualAbstract>
     // inherits FormAbstract methods
-    ->locales(['fr', 'en']) 
-    ->value(function(string $locale){ return $name[$locale]; });
+    ->locales(['fr', 'en'])
+    ->prepend(function(string $locale){
+        return 'prepend-' . $locale;
+    })
+    ->append(function(string $locale){
+        return 'append-' . $locale;
+    }) 
+    ->value(function(string $locale){
+        return $name[$locale];
+    });
 ```
 
 **Components**
@@ -252,8 +260,8 @@
 
 | Signature | Required | Description |
 |---|---|---|
-| prepend(?string $html): self | No | Prepend HTML to the button component label. Set false to hide it. |
-| append(?string $html): self | No | Append HTML to the button component label. Set false to hide it. |
+| prepend(?string $html): self | No | Prepend HTML to the button component label. Set null to hide it. |
+| append(?string $html): self | No | Append HTML to the button component label. Set null to hide it. |
 | label(string $label): self | No | Set the button component label. |
 
 **Usage**

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -48,9 +48,9 @@
 |---|---|---|
 | name(string $name): self | Yes | Set the component input name tag. |
 | model(Model $model): self | No | Set the component associated model. |
-| value($value): self | No | Set the component input value. |
-| prepend(?string $html): self | No | Prepend html to the component input group. Set false to hide it. |
-| append(?string $html): self | No | Append html to the component input group. Set false to hide it. |
+| value(mixed $value): self | No | Set the component input value. |
+| prepend(string|\Closure|string $prepend): self | No | Prepend html to the component input group. Set false to hide it. |
+| append(string|\Closure|null $html): self | No | Append html to the component input group. Set false to hide it. |
 | label(?string $label): self | No | Set the component input label. Default value : `__('validation.attributes.' .$name)`. |
 | labelPositionedAbove(bool $positionedAbove = true): self | No | Set the label above-positioning status. If not positioned above, the label will be positioned under the input (may be useful for bootstrap 4 floating labels). |
 | placeholder(?string $placeholder): self | No | Set the component input placeholder. Default value : `$label`. |
@@ -60,7 +60,7 @@
 
 **Notes**
 
-* The method `value()` accepts a closure to define the component value. To provide a fallback in case of multilingual use, the `$locale` argument can be used, which returns the current locale in case of monolingual component.
+* The `value()`, `prepend()` and `append()` methods are accepting a closure as param. To provide a fallback in case of multilingual use, this closure provides a `string $locale` argument, which is the current locale in case of monolingual component.
 
 **Usage**
 
@@ -99,6 +99,8 @@
 |---|---|---|
 | locales(array $locales): self | No | Set the component input language locales to handle. |
 | value(Closure $value): self | No | Set the component input value by returning it from this closure result : `->value(function(string $locale){})`. |
+| prepend(Closure $value): self | No | Set the component prepend value by returning it from this closure result : `->value(function(string $locale){})`. |
+| append(Closure $value): self | No | Set the component input value by returning it from this closure result : `->value(function(string $locale){})`. |
 
 **Notes**
 

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -23,8 +23,8 @@
 | componentId(string $componentId): self | No | Set the component id. |
 | containerClasses(array $containerClasses): self | No | Set the component container classes. |
 | componentClasses(array $componentClasses): self | No | Set the component classes. |
-| containerHtmlAttributes(array $containerHtmlAttributes): self | No | Set the component container html attributes. |
-| componentHtmlAttributes(array $componentHtmlAttributes): self | No | Set the component html attributes. |
+| containerHtmlAttributes(array $containerHtmlAttributes): self | No | Set the component container HTML attributes. |
+| componentHtmlAttributes(array $componentHtmlAttributes): self | No | Set the component HTML attributes. |
 
 **Usage**
 
@@ -49,18 +49,14 @@
 | name(string $name): self | Yes | Set the component input name tag. |
 | model(Model $model): self | No | Set the component associated model. |
 | value(mixed $value): self | No | Set the component input value. |
-| prepend(string|\Closure|string $prepend): self | No | Prepend html to the component input group. Set false to hide it. |
-| append(string|\Closure|null $html): self | No | Append html to the component input group. Set false to hide it. |
+| prepend(?string $prepend): self | No | Prepend HTML to the component input group. Set null to hide it. |
+| append(?string $html): self | No | Append HTML to the component input group. Set null to hide it. |
 | label(?string $label): self | No | Set the component input label. Default value : `__('validation.attributes.' .$name)`. |
 | labelPositionedAbove(bool $positionedAbove = true): self | No | Set the label above-positioning status. If not positioned above, the label will be positioned under the input (may be useful for bootstrap 4 floating labels). |
 | placeholder(?string $placeholder): self | No | Set the component input placeholder. Default value : `$label`. |
 | caption(?string $caption): self | No | Set the component caption. |
 | displaySuccess(?bool $displaySuccess = true): self | No | Set the component input validation success display status. |
 | displayFailure(?bool $displayFailure = true): self | No | Set the component input validation failure display status. |
-
-**Notes**
-
-* The `value()`, `prepend()` and `append()` methods are accepting a closure as param. To provide a fallback in case of multilingual use, this closure provides a `string $locale` argument, which is the current locale in case of monolingual component.
 
 **Usage**
 
@@ -98,20 +94,22 @@
 | Signature | Required | Description |
 |---|---|---|
 | locales(array $locales): self | No | Set the component input language locales to handle. |
+| prepend(Closure $prepend): self | No | Set the component prepended HTML by returning it from this closure result : `->prepend(function(string $locale){})`. |
+| append(Closure $append): self | No | Set the component appended HTML by returning it from this closure result : `->append(function(string $locale){})`. |
 | value(Closure $value): self | No | Set the component input value by returning it from this closure result : `->value(function(string $locale){})`. |
-| prepend(Closure $value): self | No | Set the component prepend value by returning it from this closure result : `->value(function(string $locale){})`. |
-| append(Closure $value): self | No | Set the component input value by returning it from this closure result : `->value(function(string $locale){})`. |
 
 **Notes**
 
-* Each multilingual form component will behave as a monolingual form component as long as the `->locales()` method is not used or as long as only one locale is declared.
+* You will still be able to use the `prepend`, `append` and `value` methods as for a simple `FormAbstract` component if you wish to. Closure usage is an extra behaviour, which is here to allow you to display translated content.
+* A security fallback has been implemented in order to allow you to keep the Closure behaviour for the `prepend`, `append` and `value` methods, even if your component is not multilingual anymore. The `$locale` attribute will take the value of the current locale.
+* Each multilingual form component will behave as a monolingual form component as long as the `->locales()` method is not being used or as long as only one locale is declared.
 * The use of the `->locales()` method will replicate the component for each locale keys you declared.
   * For example, if you declare the `fr` and `en` locale keys for a text input component with the `title` attribute, you will get two `Title (FR)` and `Title (EN)` generated text input components.
 * Each multilingual component provides an extra `data-locale="<locale>"` attribute to help with eventual javascript treatments.
 * You can use your own multilingual `Resolver` by replacing the path defined in the `config('bootstrap-components.form.multilingualResolver')`, allowing you to customize your multilingual form components localization behaviour :
-  * The default locales to handle (by default `[]`).
+  * The default locales to handle (default: `[]`).
   * The component localized `name` attribute resolution (default : `$name[$locale]`.
-  * The component localized old value resolution in case of errors (default : `old($name)[$locale]`).
+  * The component localized old value resolution in case of validation errors (default : `old($name)[$locale]`).
   * The component localized model value resolution (default : `$model->{$name}[$locales]`).
   * The component localized error message bag key resolution, used for the error message extraction and for the validation class generation (default : `$name . $locale`).
   * The component error message resolution, in order to correctly display the localized attribute name (default : transform `Dummy __('validation.attributes.name.en) error message` into `Dummy __('validation.attributes.name) (EN) error message.`.
@@ -162,7 +160,7 @@
 
 | Signature | Required | Description |
 |---|---|---|
-| uploadedFile(Closure $uploadedFile): self | No | Allows to set html or another component to render the uploaded file. |
+| uploadedFile(Closure $uploadedFile): self | No | Allows to set HTML or another component to render the uploaded file. |
 | showRemoveCheckbox(bool $showRemoveCheckbox = true, string $removeCheckboxLabel = null): self | No | Show the file remove checkbox option (will appear only if an uploaded file is detected). Default value : `config('bootstrap-components.file.showRemoveCheckbox')`. The remove checkbox label can be precised with the second parameter, by default, it will take the following value : `__('Remove') . ' ' . $name` |
 
 **Usage**
@@ -254,8 +252,8 @@
 
 | Signature | Required | Description |
 |---|---|---|
-| prepend(?string $html): self | No | Prepend html to the button component label. Set false to hide it. |
-| append(?string $html): self | No | Append html to the button component label. Set false to hide it. |
+| prepend(?string $html): self | No | Prepend HTML to the button component label. Set false to hide it. |
+| append(?string $html): self | No | Append HTML to the button component label. Set false to hide it. |
 | label(string $label): self | No | Set the button component label. |
 
 **Usage**
@@ -333,14 +331,14 @@
 
 | Signature | Required | Description |
 |---|---|---|
-| alt(string $alt): self | No | Define the image component alt html tag. |
-| width(int $width): self | No | Define the component image html tag width. |
-| height(int $height): self | No | Define the component image html tag height. |
+| alt(string $alt): self | No | Define the image component alt HTML tag. |
+| width(int $width): self | No | Define the component image HTML tag width. |
+| height(int $height): self | No | Define the component image HTML tag height. |
 | linkUrl(string $linkUrl): self | No | Set the image component link URL. |
 | linkTitle(string $linkTitle): self | No | Set the image component link title. |
 | linkId(string $linkId): self | No | Set the image component link id. |
 | linkClasses(array $linkClasses): self | No | Set the image component link classes. Default value : `config('bootstrap-components.media.image.classes.link')`. |
-| linkHtmlAttributes(array $linkHtmlAttributes): self | No | Set the image component link html attributes. Default value : `config('bootstrap-components.media.image.htmlAttributes.link')`. |
+| linkHtmlAttributes(array $linkHtmlAttributes): self | No | Set the image component link HTML attributes. Default value : `config('bootstrap-components.media.image.htmlAttributes.link')`. |
 
 **Usage**
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -17,3 +17,5 @@ parameters:
         - ./*/*/FileToBeExcluded.php
 
     checkMissingIterableValueType: true
+
+    treatPhpDocTypesAsCertain: false

--- a/src/ComponentServiceProvider.php
+++ b/src/ComponentServiceProvider.php
@@ -20,7 +20,7 @@ class ComponentServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__ . '/../resources/views' => resource_path('views/vendor/bootstrap-components'),
         ], 'bootstrap-components:views');
-        // we load the laravel html helper package
+        // we load the laravel HTML helper package
         // https://github.com/Okipa/laravel-html-helper
         $this->app->register(HtmlHelperServiceProvider::class);
     }

--- a/src/Components/Buttons/Abstracts/SubmitAbstract.php
+++ b/src/Components/Buttons/Abstracts/SubmitAbstract.php
@@ -27,7 +27,7 @@ abstract class SubmitAbstract extends ComponentAbstract
     }
 
     /**
-     * Prepend html to the button component label.
+     * Prepend HTML to the button component label.
      * Set false to hide it.
      *
      * @param string|null $html
@@ -42,7 +42,7 @@ abstract class SubmitAbstract extends ComponentAbstract
     }
 
     /**
-     * Append html to the button component label.
+     * Append HTML to the button component label.
      * Set false to hide it.
      *
      * @param string|null $html
@@ -99,7 +99,7 @@ abstract class SubmitAbstract extends ComponentAbstract
     }
 
     /**
-     * Set the component prepended html.
+     * Set the component prepended HTML.
      *
      * @return string
      */
@@ -114,7 +114,7 @@ abstract class SubmitAbstract extends ComponentAbstract
     }
 
     /**
-     * Set the component appended html.
+     * Set the component appended HTML.
      *
      * @return string|null
      */

--- a/src/Components/ComponentAbstract.php
+++ b/src/Components/ComponentAbstract.php
@@ -100,7 +100,7 @@ abstract class ComponentAbstract implements Htmlable
     }
 
     /**
-     * Set the component html attributes.
+     * Set the component HTML attributes.
      *
      * @param array $componentHtmlAttributes
      *
@@ -114,7 +114,7 @@ abstract class ComponentAbstract implements Htmlable
     }
 
     /**
-     * Set the component container html attributes.
+     * Set the component container HTML attributes.
      *
      * @param array $containerHtmlAttributes
      *
@@ -128,7 +128,7 @@ abstract class ComponentAbstract implements Htmlable
     }
 
     /**
-     * Render the component html.
+     * Render the component HTML.
      *
      * @return string
      * @throws \Throwable
@@ -139,7 +139,7 @@ abstract class ComponentAbstract implements Htmlable
     }
 
     /**
-     * Render the component html.
+     * Render the component HTML.
      *
      * @param array $extraData
      *
@@ -258,7 +258,7 @@ abstract class ComponentAbstract implements Htmlable
     }
 
     /**
-     * Set the component html attributes.
+     * Set the component HTML attributes.
      *
      * @return array
      */
@@ -273,7 +273,7 @@ abstract class ComponentAbstract implements Htmlable
     }
 
     /**
-     * Set the container html attributes.
+     * Set the container HTML attributes.
      *
      * @return array
      */

--- a/src/Components/Form/Abstracts/FormAbstract.php
+++ b/src/Components/Form/Abstracts/FormAbstract.php
@@ -86,7 +86,7 @@ abstract class FormAbstract extends ComponentAbstract
     }
 
     /**
-     * Prepend html to the component input group.
+     * Prepend HTML to the component input group.
      * Set null to hide it.
      *
      * @param string|Closure|null $prepend
@@ -105,7 +105,7 @@ abstract class FormAbstract extends ComponentAbstract
     }
 
     /**
-     * Append html to the component input group.
+     * Append HTML to the component input group.
      * Set null to hide it.
      *
      * @param string|Closure|null $append
@@ -288,7 +288,7 @@ abstract class FormAbstract extends ComponentAbstract
     }
 
     /**
-     * Set the component prepended html.
+     * Set the component prepended HTML.
      *
      * @return string
      */
@@ -303,7 +303,7 @@ abstract class FormAbstract extends ComponentAbstract
     }
 
     /**
-     * Set the component appended html.
+     * Set the component appended HTML.
      *
      * @return string|null
      */

--- a/src/Components/Form/Abstracts/FormAbstract.php
+++ b/src/Components/Form/Abstracts/FormAbstract.php
@@ -5,6 +5,7 @@ namespace Okipa\LaravelBootstrapComponents\Components\Form\Abstracts;
 use Closure;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 use Okipa\LaravelBootstrapComponents\Components\ComponentAbstract;
 use Okipa\LaravelBootstrapComponents\Components\Form\Traits\FormValidityChecks;
 
@@ -18,10 +19,10 @@ abstract class FormAbstract extends ComponentAbstract
     /** @property string $name */
     protected $name;
 
-    /** @property string|null $prepend */
+    /** @property string|Closure|null $prepend */
     protected $prepend;
 
-    /** @property string|null $append */
+    /** @property string|Closure|null $append */
     protected $append;
 
     /** @property string $label */
@@ -86,30 +87,38 @@ abstract class FormAbstract extends ComponentAbstract
 
     /**
      * Prepend html to the component input group.
-     * Set false to hide it.
+     * Set null to hide it.
      *
-     * @param string|null $html
+     * @param string|Closure|null $prepend
      *
      * @return $this
      */
-    public function prepend(?string $html): self
+    public function prepend($prepend): self
     {
-        $this->prepend = $html;
+        if (! is_null($prepend) && ! is_string($prepend) && ! $prepend instanceof Closure) {
+            throw new InvalidArgumentException('Invalid $prepend argument provided: null, string or \Closure value awaited. '
+                . gettype($prepend) . ' given.');
+        }
+        $this->prepend = $prepend;
 
         return $this;
     }
 
     /**
      * Append html to the component input group.
-     * Set false to hide it.
+     * Set null to hide it.
      *
-     * @param string|null $html
+     * @param string|Closure|null $append
      *
      * @return $this
      */
-    public function append(?string $html): self
+    public function append($append): self
     {
-        $this->append = $html;
+        if (! is_null($append) && ! is_string($append) && ! $append instanceof Closure) {
+            throw new InvalidArgumentException('Invalid $append argument provided: null, string or \Closure value awaited. '
+                . gettype($append) . ' given.');
+        }
+        $this->append = $append;
 
         return $this;
     }
@@ -272,7 +281,10 @@ abstract class FormAbstract extends ComponentAbstract
 
     protected function getPrepend(): ?string
     {
-        return $this->prepend;
+        $prepend = $this->prepend;
+
+        // fallback for usage of closure with multilingual disabled
+        return $prepend instanceof Closure ? $prepend(app()->getLocale()) : $prepend;
     }
 
     /**
@@ -284,7 +296,10 @@ abstract class FormAbstract extends ComponentAbstract
 
     protected function getAppend(): ?string
     {
-        return $this->append;
+        $append = $this->append;
+
+        // fallback for usage of closure with multilingual disabled
+        return $append instanceof Closure ? $append(app()->getLocale()) : $append;
     }
 
     /**
@@ -334,7 +349,7 @@ abstract class FormAbstract extends ComponentAbstract
     protected function getValue()
     {
         $value = old($this->convertArrayNameInNotation()) ?: $this->value;
-        // fallback for usage of closure with non multilingual fields
+        // fallback for usage of closure with multilingual disabled
         $value = $value instanceof Closure ? $value(app()->getLocale()) : $value;
 
         return $value ?? optional($this->getModel())->{$this->convertArrayNameInNotation()};

--- a/src/Components/Form/Abstracts/FormAbstract.php
+++ b/src/Components/Form/Abstracts/FormAbstract.php
@@ -96,8 +96,8 @@ abstract class FormAbstract extends ComponentAbstract
     public function prepend($prepend): self
     {
         if (! is_null($prepend) && ! is_string($prepend) && ! $prepend instanceof Closure) {
-            throw new InvalidArgumentException('Invalid $prepend argument provided: null, string or \Closure value awaited. '
-                . gettype($prepend) . ' given.');
+            throw new InvalidArgumentException('Invalid $prepend argument provided: null, string or ' .
+                '\Closure value awaited. ' . gettype($prepend) . ' given.');
         }
         $this->prepend = $prepend;
 
@@ -115,8 +115,8 @@ abstract class FormAbstract extends ComponentAbstract
     public function append($append): self
     {
         if (! is_null($append) && ! is_string($append) && ! $append instanceof Closure) {
-            throw new InvalidArgumentException('Invalid $append argument provided: null, string or \Closure value awaited. '
-                . gettype($append) . ' given.');
+            throw new InvalidArgumentException('Invalid $append argument provided: null, string or '
+                . '\Closure value awaited. ' . gettype($append) . ' given.');
         }
         $this->append = $append;
 

--- a/src/Components/Form/Abstracts/MultilingualAbstract.php
+++ b/src/Components/Form/Abstracts/MultilingualAbstract.php
@@ -64,7 +64,7 @@ abstract class MultilingualAbstract extends FormAbstract
     }
 
     /**
-     * Render the multilingual component html.
+     * Render the multilingual component HTML.
      *
      * @param array $extraData
      *

--- a/src/Components/Form/Abstracts/MultilingualAbstract.php
+++ b/src/Components/Form/Abstracts/MultilingualAbstract.php
@@ -115,6 +115,8 @@ abstract class MultilingualAbstract extends FormAbstract
         $containerId = $this->getLocalizedContainerId($locale);
         $componentHtmlAttributes = $this->getLocalizedComponentHtmlAttributes($locale);
         $name = $this->getLocalizedName($locale);
+        $prepend = $this->getLocalizedPrepend($locale);
+        $append = $this->getLocalizedAppend($locale);
         $label = $this->getLocalizedLabel($locale);
         $value = $this->getLocalizedValue($locale);
         $placeholder = $this->getLocalizedPlaceholder($locale);
@@ -126,6 +128,8 @@ abstract class MultilingualAbstract extends FormAbstract
             'containerId',
             'componentHtmlAttributes',
             'name',
+            'prepend',
+            'append',
             'label',
             'value',
             'placeholder',
@@ -172,6 +176,22 @@ abstract class MultilingualAbstract extends FormAbstract
     protected function getLocalizedName(string $locale): string
     {
         return $this->multilingualResolver->resolveLocalizedName($this->getName(), $locale);
+    }
+
+    protected function getLocalizedPrepend(string $locale): ?string
+    {
+        $prepend = $this->prepend;
+
+        // fallback for usage of closure with multilingual disabled
+        return $prepend instanceof Closure ? $prepend($locale) : $prepend;
+    }
+
+    protected function getLocalizedAppend(string $locale): ?string
+    {
+        $append = $this->append;
+
+        // fallback for usage of closure with multilingual disabled
+        return $append instanceof Closure ? $append($locale) : $append;
     }
 
     /**

--- a/src/Components/Media/Abstracts/ImageAbstract.php
+++ b/src/Components/Media/Abstracts/ImageAbstract.php
@@ -39,7 +39,7 @@ abstract class ImageAbstract extends MediaAbstract
     }
 
     /**
-     * Define the image component alt html tag.
+     * Define the image component alt HTML tag.
      *
      * @param string $alt
      *
@@ -53,7 +53,7 @@ abstract class ImageAbstract extends MediaAbstract
     }
 
     /**
-     * Define the component image html tag width.
+     * Define the component image HTML tag width.
      *
      * @param int $width
      *
@@ -67,7 +67,7 @@ abstract class ImageAbstract extends MediaAbstract
     }
 
     /**
-     * Define the component image html tag height.
+     * Define the component image HTML tag height.
      *
      * @param int $height
      *
@@ -137,7 +137,7 @@ abstract class ImageAbstract extends MediaAbstract
     }
 
     /**
-     * Set the image component link html attributes.
+     * Set the image component link HTML attributes.
      *
      * @param array $linkHtmlAttributes
      *
@@ -246,7 +246,7 @@ abstract class ImageAbstract extends MediaAbstract
     }
 
     /**
-     * Set the default component html attributes.
+     * Set the default component HTML attributes.
      *
      * @return array
      */
@@ -256,7 +256,7 @@ abstract class ImageAbstract extends MediaAbstract
     }
 
     /**
-     * Set the image component link html attributes.
+     * Set the image component link HTML attributes.
      *
      * @return array
      */

--- a/tests/Unit/Form/Abstracts/InputCheckableTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/InputCheckableTestAbstract.php
@@ -45,6 +45,14 @@ abstract class InputCheckableTestAbstract extends InputTestAbstract
         $this->assertStringNotContainsString('<span class="label-prepend">default-prepend</span>', $html);
     }
 
+    public function testSetPrependFromClosureWithDisabledMultilingual()
+    {
+        $html = $this->getComponent()->name('name')->prepend(function ($locale) {
+            return 'prepend-' . $locale;
+        })->toHtml();
+        $this->assertStringContainsString('<span class="label-prepend">prepend-en</span>', $html);
+    }
+
     public function testHidePrepend()
     {
         $html = $this->getComponent()->name('name')->prepend(null)->toHtml();
@@ -70,6 +78,14 @@ abstract class InputCheckableTestAbstract extends InputTestAbstract
         $html = $this->getComponent()->name('name')->append('custom-append')->toHtml();
         $this->assertStringContainsString('<span class="label-append">custom-append</span>', $html);
         $this->assertStringNotContainsString('<span class="label-append">default-append</span>', $html);
+    }
+
+    public function testSetAppendFromClosureWithDisabledMultilingual()
+    {
+        $html = $this->getComponent()->name('name')->append(function ($locale) {
+            return 'append-' . $locale;
+        })->toHtml();
+        $this->assertStringContainsString('<span class="label-append">append-en</span>', $html);
     }
 
     public function testHideAppend()
@@ -129,7 +145,7 @@ abstract class InputCheckableTestAbstract extends InputTestAbstract
         $this->assertStringNotContainsString('checked="checked', $html);
     }
 
-    public function testSetValueFromClosure()
+    public function testSetValueFromClosureWithDisabledMultilingual()
     {
         $html = $this->getComponent()->name('name')->value(function () {
             return true;

--- a/tests/Unit/Form/Abstracts/InputFileTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/InputFileTestAbstract.php
@@ -59,7 +59,7 @@ abstract class InputFileTestAbstract extends InputTestAbstract
         );
     }
 
-    public function testSetValueFromClosure()
+    public function testSetValueFromClosureWithDisabledMultilingual()
     {
         $html = $this->getComponent()->name('name')->value(function ($locale) {
             return 'closure-value-' . $locale;

--- a/tests/Unit/Form/Abstracts/InputMultilingualTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/InputMultilingualTestAbstract.php
@@ -177,6 +177,36 @@ abstract class InputMultilingualTestAbstract extends InputTestAbstract
         }
     }
 
+    public function testSetLocalizedPrepend()
+    {
+        $locales = ['fr', 'en'];
+        $html = $this->getComponent()
+            ->name('name')
+            ->locales($locales)
+            ->prepend(function ($locale) {
+                return 'prepend-' . $locale;
+            })
+            ->toHtml();
+        foreach ($locales as $locale) {
+            $this->assertStringContainsString('<span class="input-group-text">prepend-' . $locale . '</span>', $html);
+        }
+    }
+
+    public function testSetLocalizedAppend()
+    {
+        $locales = ['fr', 'en'];
+        $html = $this->getComponent()
+            ->name('name')
+            ->locales($locales)
+            ->append(function ($locale) {
+                return 'append-' . $locale;
+            })
+            ->toHtml();
+        foreach ($locales as $locale) {
+            $this->assertStringContainsString('<span class="input-group-text">append-' . $locale . '</span>', $html);
+        }
+    }
+
     public function testSetLocalizedLabel()
     {
         $locales = ['fr', 'en'];

--- a/tests/Unit/Form/Abstracts/InputRadioTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/InputRadioTestAbstract.php
@@ -47,6 +47,14 @@ abstract class InputRadioTestAbstract extends InputTestAbstract
         $this->assertStringNotContainsString('<span class="label-prepend">default-prepend</span>', $html);
     }
 
+    public function testSetPrependFromClosureWithDisabledMultilingual()
+    {
+        $html = $this->getComponent()->name('name')->prepend(function ($locale) {
+            return 'prepend-' . $locale;
+        })->toHtml();
+        $this->assertStringContainsString('<span class="label-prepend">prepend-en</span>', $html);
+    }
+
     public function testHidePrepend()
     {
         $html = $this->getComponent()->name('name')->prepend(null)->toHtml();
@@ -72,6 +80,14 @@ abstract class InputRadioTestAbstract extends InputTestAbstract
         $html = $this->getComponent()->name('name')->append('custom-append')->toHtml();
         $this->assertStringContainsString('<span class="label-append">custom-append</span>', $html);
         $this->assertStringNotContainsString('<span class="label-append">default-append</span>', $html);
+    }
+
+    public function testSetAppendFromClosureWithDisabledMultilingual()
+    {
+        $html = $this->getComponent()->name('name')->append(function ($locale) {
+            return 'append-' . $locale;
+        })->toHtml();
+        $this->assertStringContainsString('<span class="label-append">append-en</span>', $html);
     }
 
     public function testHideAppend()

--- a/tests/Unit/Form/Abstracts/InputTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/InputTestAbstract.php
@@ -4,6 +4,7 @@ namespace Okipa\LaravelBootstrapComponents\Tests\Unit\Form\Abstracts;
 
 use Exception;
 use Illuminate\Support\MessageBag;
+use InvalidArgumentException;
 use Okipa\LaravelBootstrapComponents\Components\ComponentAbstract;
 use Okipa\LaravelBootstrapComponents\Components\Form\Abstracts\FormAbstract;
 use Okipa\LaravelBootstrapComponents\Tests\BootstrapComponentsTestCase;
@@ -84,6 +85,12 @@ abstract class InputTestAbstract extends BootstrapComponentsTestCase
 
     abstract protected function getCustomComponent(): ComponentAbstract;
 
+    public function testSetWrongPrepend()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->getComponent()->name('name')->prepend(1)->toHtml();
+    }
+
     public function testSetPrependOverridesDefault()
     {
         config()->set(
@@ -93,6 +100,14 @@ abstract class InputTestAbstract extends BootstrapComponentsTestCase
         $html = $this->getComponent()->name('name')->prepend('custom-prepend')->toHtml();
         $this->assertStringContainsString('<span class="input-group-text">custom-prepend</span>', $html);
         $this->assertStringNotContainsString('<span class="input-group-text">default-prepend</span>', $html);
+    }
+
+    public function testSetPrependFromClosureWithDisabledMultilingual()
+    {
+        $html = $this->getComponent()->name('name')->prepend(function ($locale) {
+            return 'prepend-' . $locale;
+        })->toHtml();
+        $this->assertStringContainsString('<span class="input-group-text">prepend-en</span>', $html);
     }
 
     public function testHidePrepend()
@@ -111,6 +126,12 @@ abstract class InputTestAbstract extends BootstrapComponentsTestCase
         $this->assertStringContainsString('<span class="input-group-text">default-append</span>', $html);
     }
 
+    public function testSetWrongAppend()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->getComponent()->name('name')->append(1)->toHtml();
+    }
+
     public function testSetAppendOverridesDefault()
     {
         config()->set(
@@ -120,6 +141,14 @@ abstract class InputTestAbstract extends BootstrapComponentsTestCase
         $html = $this->getComponent()->name('name')->append('custom-append')->toHtml();
         $this->assertStringContainsString('<span class="input-group-text">custom-append</span>', $html);
         $this->assertStringNotContainsString('<span class="input-group-text">default-append</span>', $html);
+    }
+
+    public function testSetAppendFromClosureWithDisabledMultilingual()
+    {
+        $html = $this->getComponent()->name('name')->append(function ($locale) {
+            return 'append-' . $locale;
+        })->toHtml();
+        $this->assertStringContainsString('<span class="input-group-text">append-en</span>', $html);
     }
 
     public function testHideAppend()
@@ -185,7 +214,7 @@ abstract class InputTestAbstract extends BootstrapComponentsTestCase
         $this->assertStringContainsString(' value=""', $html);
     }
 
-    public function testSetValueFromClosure()
+    public function testSetValueFromClosureWithDisabledMultilingual()
     {
         $html = $this->getComponent()->name('name')->value(function ($locale) {
             return 'closure-value-' . $locale;

--- a/tests/Unit/Form/Abstracts/SelectTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/SelectTestAbstract.php
@@ -138,7 +138,7 @@ abstract class SelectTestAbstract extends InputTestAbstract
         $this->markTestSkipped();
     }
 
-    public function testSetValueFromClosure()
+    public function testSetValueFromClosureWithDisabledMultilingual()
     {
         $this->markTestSkipped();
     }

--- a/tests/Unit/Form/Abstracts/TemporalTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/TemporalTestAbstract.php
@@ -101,7 +101,7 @@ abstract class TemporalTestAbstract extends InputTestAbstract
         $this->assertStringContainsString(' value=""', $html);
     }
 
-    public function testSetValueFromClosure()
+    public function testSetValueFromClosureWithDisabledMultilingual()
     {
         $value = $this->faker->dateTime;
         $html = $this->getComponent()->name('name')->value(function () use ($value) {

--- a/tests/Unit/Form/Abstracts/TextareaTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/TextareaTestAbstract.php
@@ -44,7 +44,7 @@ abstract class TextareaTestAbstract extends InputMultilingualTestAbstract
         $this->assertStringContainsString('></textarea>', $html);
     }
 
-    public function testSetValueFromClosure()
+    public function testSetValueFromClosureWithDisabledMultilingual()
     {
         $html = $this->getComponent()->name('name')->value(function ($locale) {
             return 'closure-value-' . $locale;


### PR DESCRIPTION
* Added the possibility to use a closure as argument for the `prepend` and `append` methods of the [multilingual components](docs/api/types.md#multilingualabstract), in order to translate rendered prepended or appended HTML.