### PR TITLE
Validation improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [5.0.1](https://github.com/Okipa/laravel-bootstrap-components/compare/5.0.0...5.0.1)
+
+2020-12-11
+
+* The `Field correctly filled.` validation feedback sentence has been removed. The `is-valid` class is enough to highlight valid fields and this will avoid forms overloading.
+* The `bootstrap-components.form.formValidation.displaySuccess` config value is now set to `true` by default, in order to highlight valid fields when some of them are in error.
+* In relation with the 2 points above, you're advised to pass the `bootstrap-components.form.formValidation.displaySuccess` config value to `true` if you published the package configuration file, in order to improve the ergonomics of your forms.
+
 ## [5.0.0](https://github.com/Okipa/laravel-bootstrap-components/compare/4.0.0...5.0.0)
 
 2020-12-02

--- a/README.md
+++ b/README.md
@@ -184,7 +184,6 @@ Here is the list of the words and sentences available for translation:
 * `Awaited format: Hour:Minutes.`
 * `Awaited format: Day/Month/Year Hour:Minutes.`
 * `Your browser does not support the :tag HTML5 tag.`
-* `Field correctly filled.`
 
 You will also have to define each attribute you define in the `->name()` method in the `validation` (`attributes` key) translation file.
 

--- a/config/bootstrap-components.php
+++ b/config/bootstrap-components.php
@@ -2,12 +2,12 @@
 
 return [
 
-    /*
+    /**
      * The fully qualified class name of the components.
      * Here you can override them. Make sure your custom component extends the overridden one.
      */
     'components' => [
-        // Form
+        // Form components
         'text' => Okipa\LaravelBootstrapComponents\Components\Form\InputText::class,
         'email' => Okipa\LaravelBootstrapComponents\Components\Form\InputEmail::class,
         'password' => Okipa\LaravelBootstrapComponents\Components\Form\InputPassword::class,
@@ -24,7 +24,7 @@ return [
         'radio' => Okipa\LaravelBootstrapComponents\Components\Form\InputRadio::class,
         'textarea' => Okipa\LaravelBootstrapComponents\Components\Form\Textarea::class,
         'select' => Okipa\LaravelBootstrapComponents\Components\Form\Select::class,
-        // Buttons
+        // Buttons components
         'submit' => Okipa\LaravelBootstrapComponents\Components\Buttons\Submit::class,
         'create' => Okipa\LaravelBootstrapComponents\Components\Buttons\SubmitCreate::class,
         'update' => Okipa\LaravelBootstrapComponents\Components\Buttons\SubmitUpdate::class,
@@ -33,34 +33,30 @@ return [
         'link' => Okipa\LaravelBootstrapComponents\Components\Buttons\ButtonLink::class,
         'back' => Okipa\LaravelBootstrapComponents\Components\Buttons\ButtonBack::class,
         'cancel' => Okipa\LaravelBootstrapComponents\Components\Buttons\ButtonCancel::class,
-        // Media
+        // Media components
         'image' => Okipa\LaravelBootstrapComponents\Components\Media\Image::class,
         'audio' => Okipa\LaravelBootstrapComponents\Components\Media\Audio::class,
         'video' => Okipa\LaravelBootstrapComponents\Components\Media\Video::class,
     ],
 
-    /*
-    * Form components specific configuration.
-    */
+    /** Form components specific configuration. */
     'form' => [
-        /*
+        /**
          * The fully qualified class name of the multilingual resolver.
          * You can override it. Make sure your custom resolver extends this one.
          */
         'multilingualResolver' => Okipa\LaravelBootstrapComponents\Components\Form\Multilingual\Resolver::class,
 
-        /*
+        /**
          * Whether the form component label is positioned above the component itself.
          * If not positioned above, the label will be positioned under the input
          * (may be useful for bootstrap 4 floating labels).
          */
         'labelPositionedAbove' => true,
 
-        /*
-         * Whether the form component should display its success or failure status.
-         */
+        /** Whether the form component should display its success or failure status. */
         'formValidation' => [
-            'displaySuccess' => false,
+            'displaySuccess' => true,
             'displayFailure' => true,
         ],
     ],

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -55,8 +55,8 @@
 | labelPositionedAbove(bool $positionedAbove = true): self | No | Set the label above-positioning status. If not positioned above, the label will be positioned under the input (may be useful for bootstrap 4 floating labels). |
 | placeholder(?string $placeholder): self | No | Set the component input placeholder. Default value : `$label`. |
 | caption(?string $caption): self | No | Set the component caption. |
-| displaySuccess(?bool $displaySuccess = true): self | No | Set the component input validation success display status. |
-| displayFailure(?bool $displayFailure = true): self | No | Set the component input validation failure display status. |
+| displaySuccess(?bool $displaySuccess = true): self | No | Override the component default input validation success display status. Valid fields will only be highlighted as valid if other are in error. |
+| displayFailure(?bool $displayFailure = true): self | No | Override the component default input validation failure display status. Invalid fields will only be highlighted if the `$errors` blade variable contains an error related to the component input name. |
 | errorBag(string $errorBag): self | No | Define the name of the error bag that will contain the error related to this input. By default, the Laravel error bag is `default`. |
 
 **Usage**

--- a/resources/views/bootstrap-components/partials/validation-feedback.blade.php
+++ b/resources/views/bootstrap-components/partials/validation-feedback.blade.php
@@ -2,8 +2,4 @@
     <div class="invalid-feedback d-block">
         {!! $errorMessage !!}
     </div>
-@elseif($successMessage = $successMessage())
-    <div class="valid-feedback d-block">
-        {!! $successMessage !!}
-    </div>
 @endif

--- a/src/Components/Form/Abstracts/FormAbstract.php
+++ b/src/Components/Form/Abstracts/FormAbstract.php
@@ -159,7 +159,6 @@ abstract class FormAbstract extends ComponentAbstract
         return array_merge(parent::getViewParams(), [
             'validationClass' => fn(?ViewErrorBag $errors) => $this->getValidationClass($errors),
             'errorMessage' => fn(?ViewErrorBag $errors) => $this->getErrorMessage($errors),
-            'successMessage' => fn() => $this->getSuccessMessage(),
             'labelPositionedAbove' => $this->getLabelPositionedAbove(),
             'label' => $this->getLabel(),
             'type' => $this->getType(),
@@ -227,15 +226,6 @@ abstract class FormAbstract extends ComponentAbstract
         }
 
         return $this->getErrorMessageBag($errors)->first($this->convertArrayNameInNotation());
-    }
-
-    protected function getSuccessMessage(): ?string
-    {
-        if ($this->getDisplaySuccess()) {
-            return (string) __('Field correctly filled.');
-        }
-
-        return null;
     }
 
     protected function getLabelPositionedAbove(): bool

--- a/src/Components/Form/Abstracts/MultilingualAbstract.php
+++ b/src/Components/Form/Abstracts/MultilingualAbstract.php
@@ -85,7 +85,6 @@ abstract class MultilingualAbstract extends FormAbstract
                 ?ViewErrorBag $errors,
                 ?string $locale
             ) => $this->getLocalizedErrorMessage($errors, $locale),
-            'successMessage' => fn() => $this->getSuccessMessage(),
             'labelPositionedAbove' => $this->getLabelPositionedAbove(),
             'label' => $this->getLocalizedLabel($locale),
             'type' => $this->getType(),

--- a/tests/Unit/Form/Abstracts/InputTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/InputTestAbstract.php
@@ -363,11 +363,9 @@ abstract class InputTestAbstract extends BootstrapComponentsTestCase
         $errors = app(ViewErrorBag::class)->put('default', $messageBag);
         $html = $this->getComponent()->name('name')->render(compact('errors'));
         self::assertStringContainsString('is-valid', $html);
-        self::assertStringContainsString('<div class="valid-feedback d-block">', $html);
-        self::assertStringContainsString(__('Field correctly filled.'), $html);
     }
 
-    public function testSetDisplaySuccessReplacesDefault(): void
+    public function testSetDisplaySuccessOverridesDefault(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),
@@ -377,8 +375,6 @@ abstract class InputTestAbstract extends BootstrapComponentsTestCase
         $errors = app(ViewErrorBag::class)->put('default', $messageBag);
         $html = $this->getComponent()->name('name')->displaySuccess(false)->render(compact('errors'));
         self::assertStringNotContainsString('is-valid', $html);
-        self::assertStringNotContainsString('<div class="valid-feedback d-block">', $html);
-        self::assertStringNotContainsString(__('Field correctly filled.'), $html);
     }
 
     public function testSetCustomDisplayFailure(): void


### PR DESCRIPTION
* The `Field correctly filled.` validation feedback sentence has been removed. The `is-valid` class is enough to highlight valid fields and this will avoid forms overloading.
* The `bootstrap-components.form.formValidation.displaySuccess` config value is now set to `true` by default, in order to highlight valid fields when some of them are in error.
* In relation with the 2 points above, you're advised to pass the `bootstrap-components.form.formValidation.displaySuccess` config value to `true` if you published the package configuration file, in order to improve the ergonomics of your forms.