### PR TITLE
validation-class-fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
 # Changelog
 
+## [5.0.2](https://github.com/Okipa/laravel-bootstrap-components/compare/5.0.1...5.0.2)
+
+2020-12-13
+
+* Fixed the `is-valid` class displaying conditions: this class now **only** appears if the field has a filled value (will not appear otherwise)
+  * This change allows form components to be highlighted as valid when they are being filled or after the were filled with real-time validation and re-rendering (improves Livewire use)
+  * It does not change the behaviour for a form post-submission page reloading standard use-case
+
 ## [5.0.1](https://github.com/Okipa/laravel-bootstrap-components/compare/5.0.0...5.0.1)
 
 2020-12-11
 
-* The `Field correctly filled.` validation feedback sentence has been removed. The `is-valid` class is enough to highlight valid fields and this will avoid forms overloading.
-* The `bootstrap-components.form.formValidation.displaySuccess` config value is now set to `true` by default, in order to highlight valid fields when some of them are in error.
-* In relation with the 2 points above, you're advised to pass the `bootstrap-components.form.formValidation.displaySuccess` config value to `true` if you published the package configuration file, in order to improve the ergonomics of your forms.
+* The `Field correctly filled.` validation feedback sentence has been removed. The `is-valid` class is enough to highlight valid fields and this will avoid forms overloading
+* The `bootstrap-components.form.formValidation.displaySuccess` config value is now set to `true` by default, in order to highlight valid fields when some of them are in error
+* In relation with the 2 points above, you're advised to pass the `bootstrap-components.form.formValidation.displaySuccess` config value to `true` if you published the package configuration file, in order to improve the ergonomics of your forms
 
 ## [5.0.0](https://github.com/Okipa/laravel-bootstrap-components/compare/4.0.0...5.0.0)
 

--- a/tests/Unit/Buttons/Abstracts/ButtonTestAbstract.php
+++ b/tests/Unit/Buttons/Abstracts/ButtonTestAbstract.php
@@ -44,7 +44,7 @@ abstract class ButtonTestAbstract extends SubmitTestAbstract
         self::assertStringContainsString('href="' . route($customRoute) . '"', $html);
     }
 
-    public function testSetCustomLabel(): void
+    public function testDefaultLabel(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),

--- a/tests/Unit/Buttons/Abstracts/SubmitTestAbstract.php
+++ b/tests/Unit/Buttons/Abstracts/SubmitTestAbstract.php
@@ -39,7 +39,7 @@ abstract class SubmitTestAbstract extends BootstrapComponentsTestCase
         self::assertStringContainsString(' <button type="' . $this->getComponentType() . '"', $html);
     }
 
-    public function testSetCustomPrepend(): void
+    public function testDefaultPrepend(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),
@@ -71,7 +71,7 @@ abstract class SubmitTestAbstract extends BootstrapComponentsTestCase
         self::assertStringNotContainsString('<span class="label-prepend">', $html);
     }
 
-    public function testSetCustomAppend(): void
+    public function testDefaultAppend(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),
@@ -105,7 +105,7 @@ abstract class SubmitTestAbstract extends BootstrapComponentsTestCase
         self::assertStringNotContainsString('<span class="label-append">', $html);
     }
 
-    public function testSetCustomLabel(): void
+    public function testDefaultLabel(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),
@@ -169,7 +169,7 @@ abstract class SubmitTestAbstract extends BootstrapComponentsTestCase
         self::assertStringContainsString('<button id="' . $customComponentId . '"', $html);
     }
 
-    public function testSetCustomContainerClasses(): void
+    public function testDefaultContainerClasses(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),
@@ -199,7 +199,7 @@ abstract class SubmitTestAbstract extends BootstrapComponentsTestCase
         self::assertStringContainsString('class="component-container replaces default"', $html);
     }
 
-    public function testSetCustomComponentClasses(): void
+    public function testDefaultComponentClasses(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),
@@ -229,7 +229,7 @@ abstract class SubmitTestAbstract extends BootstrapComponentsTestCase
         self::assertStringContainsString('class="component btn replaces default"', $html);
     }
 
-    public function testSetCustomContainerHtmlAttributes(): void
+    public function testDefaultContainerHtmlAttributes(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),
@@ -259,7 +259,7 @@ abstract class SubmitTestAbstract extends BootstrapComponentsTestCase
         self::assertStringContainsString('replaces="default">', $html);
     }
 
-    public function testSetCustomComponentHtmlAttributes(): void
+    public function testDefaultComponentHtmlAttributes(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),

--- a/tests/Unit/Form/Abstracts/InputCheckableTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/InputCheckableTestAbstract.php
@@ -24,7 +24,7 @@ abstract class InputCheckableTestAbstract extends InputTestAbstract
         self::assertStringContainsString(' checked="checked"', $html);
     }
 
-    public function testSetCustomPrepend(): void
+    public function testDefaultPrepend(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),
@@ -59,7 +59,7 @@ abstract class InputCheckableTestAbstract extends InputTestAbstract
         self::assertStringNotContainsString('<div class="label-prepend">', $html);
     }
 
-    public function testSetCustomAppend(): void
+    public function testDefaultAppend(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),
@@ -217,7 +217,7 @@ abstract class InputCheckableTestAbstract extends InputTestAbstract
             . 'validation.attributes.active</label>', $html);
     }
 
-    public function testSetCustomLabelPositionedAbove(): void
+    public function testDefaultLabelPositionedAbove(): void
     {
         self::markTestSkipped();
     }
@@ -267,7 +267,7 @@ abstract class InputCheckableTestAbstract extends InputTestAbstract
         self::markTestSkipped();
     }
 
-    public function testSetCustomContainerClasses(): void
+    public function testDefaultContainerClasses(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),
@@ -308,7 +308,7 @@ abstract class InputCheckableTestAbstract extends InputTestAbstract
         );
     }
 
-    public function testSetCustomComponentClasses(): void
+    public function testDefaultComponentClasses(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),

--- a/tests/Unit/Form/Abstracts/InputFileTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/InputFileTestAbstract.php
@@ -157,7 +157,7 @@ abstract class InputFileTestAbstract extends InputTestAbstract
             . '-name">' . __('No file selected.') . '</label>', $html);
     }
 
-    public function testSetCustomComponentClasses(): void
+    public function testDefaultComponentClasses(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),
@@ -256,7 +256,7 @@ abstract class InputFileTestAbstract extends InputTestAbstract
         );
     }
 
-    public function testSetCustomRemoveCheckboxLabel(): void
+    public function testSetRemoveCheckboxLabel(): void
     {
         $html = $this->getComponent()->name('name')->uploadedFile(function () {
             return 'html';

--- a/tests/Unit/Form/Abstracts/InputRadioTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/InputRadioTestAbstract.php
@@ -2,6 +2,8 @@
 
 namespace Okipa\LaravelBootstrapComponents\Tests\Unit\Form\Abstracts;
 
+use Illuminate\Support\MessageBag;
+use Illuminate\Support\ViewErrorBag;
 use InvalidArgumentException;
 use Okipa\LaravelBootstrapComponents\Components\Form\Abstracts\RadioAbstract;
 
@@ -25,7 +27,7 @@ abstract class InputRadioTestAbstract extends InputTestAbstract
         self::assertStringContainsString('checked="checked"', $html);
     }
 
-    public function testSetCustomPrepend(): void
+    public function testDefaultPrepend(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),
@@ -60,7 +62,7 @@ abstract class InputRadioTestAbstract extends InputTestAbstract
         self::assertStringNotContainsString('<div class="label-prepend">', $html);
     }
 
-    public function testSetCustomAppend(): void
+    public function testDefaultAppend(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),
@@ -193,7 +195,19 @@ abstract class InputRadioTestAbstract extends InputTestAbstract
         );
     }
 
-    public function testSetCustomLabelPositionedAbove(): void
+    public function testDoesNotDisplaySuccessWithNoValue(): void
+    {
+        config()->set(
+            'bootstrap-components.components.' . $this->getComponentKey(),
+            get_class($this->getCustomComponent())
+        );
+        $messageBag = app(MessageBag::class)->add('other_name', 'Dummy error message.');
+        $errors = app(ViewErrorBag::class)->put('default', $messageBag);
+        $html = $this->getComponent()->name('name')->value(null)->render(compact('errors'));
+        self::assertStringNotContainsString('is-valid', $html);
+    }
+
+    public function testDefaultLabelPositionedAbove(): void
     {
         self::markTestSkipped();
     }
@@ -264,7 +278,7 @@ abstract class InputRadioTestAbstract extends InputTestAbstract
         self::assertStringContainsString('<input id="' . $this->getComponentType() . '-camel-case-name-value"', $html);
     }
 
-    public function testSetCustomContainerClasses(): void
+    public function testDefaultContainerClasses(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),
@@ -300,7 +314,7 @@ abstract class InputRadioTestAbstract extends InputTestAbstract
         self::assertStringContainsString('class="component-container custom-control custom-checkbox replaced"', $html);
     }
 
-    public function testSetCustomComponentClasses(): void
+    public function testDefaultComponentClasses(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),

--- a/tests/Unit/Form/Abstracts/InputTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/InputTestAbstract.php
@@ -68,7 +68,7 @@ abstract class InputTestAbstract extends BootstrapComponentsTestCase
         self::assertStringContainsString(' value="' . $user->name . '"', $html);
     }
 
-    public function testSetCustomPrepend(): void
+    public function testDefaultPrepend(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),
@@ -116,7 +116,7 @@ abstract class InputTestAbstract extends BootstrapComponentsTestCase
         self::assertStringNotContainsString('<div class="input-group-prepend">', $html);
     }
 
-    public function testSetCustomAppend(): void
+    public function testDefaultAppend(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),
@@ -163,7 +163,7 @@ abstract class InputTestAbstract extends BootstrapComponentsTestCase
         self::assertStringNotContainsString('<div class="input-group">', $html);
     }
 
-    public function testSetCustomCaption(): void
+    public function testDefaultCaption(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),
@@ -281,7 +281,7 @@ abstract class InputTestAbstract extends BootstrapComponentsTestCase
         );
     }
 
-    public function testSetCustomLabelPositionedAbove(): void
+    public function testDefaultLabelPositionedAbove(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),
@@ -353,7 +353,19 @@ abstract class InputTestAbstract extends BootstrapComponentsTestCase
         self::assertStringNotContainsString(' placeholder="', $html);
     }
 
-    public function testSetCustomDisplaySuccess(): void
+    public function testDefaultDisplaySuccess(): void
+    {
+        config()->set(
+            'bootstrap-components.components.' . $this->getComponentKey(),
+            get_class($this->getCustomComponent())
+        );
+        $messageBag = app(MessageBag::class)->add('other_name', 'Dummy error message.');
+        $errors = app(ViewErrorBag::class)->put('default', $messageBag);
+        $html = $this->getComponent()->name('name')->value('test')->render(compact('errors'));
+        self::assertStringContainsString('is-valid', $html);
+    }
+
+    public function testDoesNotDisplaySuccessWithNoValue(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),
@@ -362,7 +374,7 @@ abstract class InputTestAbstract extends BootstrapComponentsTestCase
         $messageBag = app(MessageBag::class)->add('other_name', 'Dummy error message.');
         $errors = app(ViewErrorBag::class)->put('default', $messageBag);
         $html = $this->getComponent()->name('name')->render(compact('errors'));
-        self::assertStringContainsString('is-valid', $html);
+        self::assertStringNotContainsString('is-valid', $html);
     }
 
     public function testSetDisplaySuccessOverridesDefault(): void
@@ -373,11 +385,11 @@ abstract class InputTestAbstract extends BootstrapComponentsTestCase
         );
         $messageBag = app(MessageBag::class)->add('other_name', 'Dummy error message.');
         $errors = app(ViewErrorBag::class)->put('default', $messageBag);
-        $html = $this->getComponent()->name('name')->displaySuccess(false)->render(compact('errors'));
+        $html = $this->getComponent()->name('name')->value('test')->displaySuccess(false)->render(compact('errors'));
         self::assertStringNotContainsString('is-valid', $html);
     }
 
-    public function testSetCustomDisplayFailure(): void
+    public function testDefaultDisplayFailure(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),
@@ -471,7 +483,7 @@ abstract class InputTestAbstract extends BootstrapComponentsTestCase
         self::assertStringContainsString('<input id="' . $customComponentId . '"', $html);
     }
 
-    public function testSetCustomContainerClasses(): void
+    public function testDefaultContainerClasses(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),
@@ -501,7 +513,7 @@ abstract class InputTestAbstract extends BootstrapComponentsTestCase
         self::assertStringContainsString('class="component-container replaced"', $html);
     }
 
-    public function testSetCustomComponentClasses(): void
+    public function testDefaultComponentClasses(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),
@@ -531,7 +543,7 @@ abstract class InputTestAbstract extends BootstrapComponentsTestCase
         self::assertStringContainsString('class="component form-control replaced"', $html);
     }
 
-    public function testSetCustomContainerHtmlAttributes(): void
+    public function testDefaultContainerHtmlAttributes(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),
@@ -561,7 +573,7 @@ abstract class InputTestAbstract extends BootstrapComponentsTestCase
         self::assertStringContainsString('replaces="default">', $html);
     }
 
-    public function testSetCustomComponentHtmlAttributes(): void
+    public function testDefaultComponentHtmlAttributes(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),

--- a/tests/Unit/Form/Abstracts/SelectTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/SelectTestAbstract.php
@@ -554,7 +554,7 @@ abstract class SelectTestAbstract extends InputTestAbstract
         }
     }
 
-    public function testSetCustomLabelPositionedAbove(): void
+    public function testDefaultLabelPositionedAbove(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),
@@ -678,7 +678,7 @@ abstract class SelectTestAbstract extends InputTestAbstract
         self::assertStringContainsString('<select id="' . $customComponentId . '"', $html);
     }
 
-    public function testSetCustomComponentClasses(): void
+    public function testDefaultComponentClasses(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),

--- a/tests/Unit/Form/Abstracts/TemporalTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/TemporalTestAbstract.php
@@ -3,6 +3,8 @@
 namespace Okipa\LaravelBootstrapComponents\Tests\Unit\Form\Abstracts;
 
 use Carbon\Carbon;
+use Illuminate\Support\MessageBag;
+use Illuminate\Support\ViewErrorBag;
 use Okipa\LaravelBootstrapComponents\Components\Form\Abstracts\TemporalAbstract;
 use RuntimeException;
 
@@ -39,7 +41,35 @@ abstract class TemporalTestAbstract extends InputTestAbstract
         $this->getComponent()->model($user)->name('name')->toHtml();
     }
 
-    public function testSetCustomFormat(): void
+    public function testDefaultDisplaySuccess(): void
+    {
+        config()->set(
+            'bootstrap-components.components.' . $this->getComponentKey(),
+            get_class($this->getCustomComponent())
+        );
+        $messageBag = app(MessageBag::class)->add('other_name', 'Dummy error message.');
+        $errors = app(ViewErrorBag::class)->put('default', $messageBag);
+        $html = $this->getComponent()->name('name')->value($this->faker->dateTime)->render(compact('errors'));
+        self::assertStringContainsString('is-valid', $html);
+    }
+
+    public function testSetDisplaySuccessOverridesDefault(): void
+    {
+        config()->set(
+            'bootstrap-components.components.' . $this->getComponentKey(),
+            get_class($this->getCustomComponent())
+        );
+        $messageBag = app(MessageBag::class)->add('other_name', 'Dummy error message.');
+        $errors = app(ViewErrorBag::class)->put('default', $messageBag);
+        $html = $this->getComponent()
+            ->name('name')
+            ->value($this->faker->dateTime)
+            ->displaySuccess(false)
+            ->render(compact('errors'));
+        self::assertStringNotContainsString('is-valid', $html);
+    }
+
+    public function testDefaultFormat(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),

--- a/tests/Unit/Form/Abstracts/TextareaTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/TextareaTestAbstract.php
@@ -74,7 +74,7 @@ abstract class TextareaTestAbstract extends InputMultilingualTestAbstract
         self::assertStringNotContainsString('custom-value</textarea>', $html);
     }
 
-    public function testSetCustomLabelPositionedAbove(): void
+    public function testDefaultLabelPositionedAbove(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),

--- a/tests/Unit/Media/Abstracts/ImageTestAbstract.php
+++ b/tests/Unit/Media/Abstracts/ImageTestAbstract.php
@@ -116,7 +116,7 @@ abstract class ImageTestAbstract extends MediaTestAbstract
         self::assertStringContainsString('<img id="' . $customComponentId . '"', $html);
     }
 
-    public function testSetCustomLinkClasses(): void
+    public function testDefaultLinkClasses(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),
@@ -146,7 +146,7 @@ abstract class ImageTestAbstract extends MediaTestAbstract
         self::assertStringContainsString('class="component-link replaces default"', $html);
     }
 
-    public function testSetCustomLinkHtmlAttributes(): void
+    public function testDefaultLinkHtmlAttributes(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),

--- a/tests/Unit/Media/Abstracts/MediaTestAbstract.php
+++ b/tests/Unit/Media/Abstracts/MediaTestAbstract.php
@@ -48,7 +48,7 @@ abstract class MediaTestAbstract extends BootstrapComponentsTestCase
         self::assertStringNotContainsString('<source src="', $html);
     }
 
-    public function testSetCustomCaption(): void
+    public function testDefaultCaption(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),
@@ -125,7 +125,7 @@ abstract class MediaTestAbstract extends BootstrapComponentsTestCase
         self::assertStringContainsString('<audio id="custom-component-id"', $html);
     }
 
-    public function testSetCustomContainerClasses(): void
+    public function testDefaultContainerClasses(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),
@@ -155,7 +155,7 @@ abstract class MediaTestAbstract extends BootstrapComponentsTestCase
         self::assertStringContainsString('class="component-container replaces default"', $html);
     }
 
-    public function testSetCustomComponentClasses(): void
+    public function testDefaultComponentClasses(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),
@@ -185,7 +185,7 @@ abstract class MediaTestAbstract extends BootstrapComponentsTestCase
         self::assertStringContainsString('class="component replaces default"', $html);
     }
 
-    public function testSetCustomContainerHtmlAttributes(): void
+    public function testDefaultContainerHtmlAttributes(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),
@@ -219,7 +219,7 @@ abstract class MediaTestAbstract extends BootstrapComponentsTestCase
         self::assertStringContainsString('replaces="default">', $html);
     }
 
-    public function testSetCustomComponentHtmlAttributes(): void
+    public function testDefaultComponentHtmlAttributes(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),

--- a/tests/Unit/Media/Abstracts/VideoTestAbstract.php
+++ b/tests/Unit/Media/Abstracts/VideoTestAbstract.php
@@ -4,7 +4,7 @@ namespace Okipa\LaravelBootstrapComponents\Tests\Unit\Media\Abstracts;
 
 abstract class VideoTestAbstract extends MediaTestAbstract
 {
-    public function testSetCustomPoster(): void
+    public function testDefaultPoster(): void
     {
         config()->set(
             'bootstrap-components.components.' . $this->getComponentKey(),


### PR DESCRIPTION
* Fixed the `is-valid` class displaying conditions: this class now **only** appears if the field has a filled value (will not appear otherwise)
  * This change allows form components to be highlighted as valid when they are being filled or after the were filled with real-time validation and re-rendering (improves Livewire use)
  * It does not change the behaviour for a form post-submission page reloading standard use-case