### PR TITLE
Added the ability to disable the select component placeholder option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [5.1.0](https://github.com/Okipa/laravel-bootstrap-components/compare/5.0.2...5.1.0)
+
+2021-02-20
+
+* Added the ability to disable the select component placeholder option with the new `->disablePlaceholder()` method
+* Deprecations :
+  * The select component `->disabled()` method usages should be replaced by `->disableOptions()`
+  * The select component `->selected()` method usages should be replaced by `->selectOptions()`
+  * These deprecated methods will be removed in the next major version
+  * These renaming are improving understanding about what these methods are actually doing
+
 ## [5.0.2](https://github.com/Okipa/laravel-bootstrap-components/compare/5.0.1...5.0.2)
 
 2021-01-25

--- a/composer.json
+++ b/composer.json
@@ -52,8 +52,8 @@
             "vendor/bin/phpcbf",
             "vendor/bin/phpcs",
             "vendor/bin/phpmd config,src text phpmd.xml",
-            "vendor/bin/phpstan analyse --memory-limit=-1 --error-format=table",
-            "vendor/bin/phpunit -d memory_limit=-1 --testdox --coverage-text"
+            "vendor/bin/phpstan analyse --memory-limit=2G",
+            "vendor/bin/phpunit -d memory_limit=-1"
         ]
     },
     "extra": {

--- a/docs/api/components.md
+++ b/docs/api/components.md
@@ -240,18 +240,13 @@
 
 **Facade :** `InputSwitch`
 
-**Notes**
-
-* This component is an extra component not included in bootstrap and using it demands to [load the package styles](#styles).
-* The following classes can be applied in the `containerClasses()` method in order to manage the input toggle size : `toggle-sm` , `toggle-lg`.
-
 **Pre-configuration**
 
 * Container classes : : `form-group`
 * Display success : `config('bootstrap-components.form.formValidation.displaySuccess')`
 * Display failure : `config('bootstrap-components.form.formValidation.displayFailure')`
 
-## input radio
+## Input radio
 
 **Type :** [CheckableAbstract](./types.md#checkableabstract)
 
@@ -292,10 +287,6 @@
 **Helper :** `select()`
 
 **Facade :** `Select`
-
-**Notes**
-* in `single` mode, the selected() method second attribute only accept a string or an integer.
-* in `multiple` mode, the selected() method second attribute only accept an array.
 
 **Pre-configuration**
 

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -63,7 +63,7 @@
 
 ```php
 <FormAbstract>
-    // inherits ComponentAbstract methods
+    // Inherits ComponentAbstract methods
     ->name('email')
     ->model($user)
     ->value('john.doe@domain.com')
@@ -120,7 +120,7 @@
 
 ```php
 <MultilingualAbstract>
-    // inherits FormAbstract methods
+    // Inherits FormAbstract methods
     ->locales(['fr', 'en'])
     ->value(fn(string $locale) => $name[$locale]);
     ->prepend(fn(string $locale) => 'prepend-' . $locale)
@@ -146,7 +146,7 @@
 
 ```php
 <TemporalAbstract>
-    // inherits FormAbstract methods
+    // Inherits FormAbstract methods
     ->format('Y-m-d H:i');
 ```
 
@@ -171,7 +171,7 @@
 
 ```php
 <UploadableAbstract>
-    // inherits FormAbstract methods
+    // Inherits FormAbstract methods
     ->uploadedFile(fn() => '<div>Some HTML</div>')
     ->showRemoveCheckbox(true, 'Remove this file');
 ```
@@ -198,7 +198,7 @@
 
 ```php
 <CheckableAbstract>
-    // inherits FormAbstract methods
+    // Inherits FormAbstract methods
     ->checked();
 ```
 
@@ -216,27 +216,29 @@
 
 | Signature | Required | Description |
 |---|---|---|
-| options(iterable $optionsList, string $optionValueField, string $optionLabelField): self | No | Set the options list (array or models collection) and declare which fields should be used for the options values and labels. |
-| selected(string $fieldToCompare, $valueToCompare): self | No | Choose which option should be selected, declaring the field and the value to compare with the declared options list. |
-| disabled(Closure $disabledOptions): self | No | Choose which option should be disabled by returning a boolean value from this closure result : `->disabled(function(array $option){})`. |
-| multiple(bool $multiple = true): self | No | Set the select multiple mode. |
+| disablePlaceholder(): self | No | Disable the select placeholder option. |
+| multiple(bool $multiple = true): self | No | Define whether the select is in multiple mode or not. |
+| options(iterable $optionsList, string $optionValueField, string $optionLabelField): self | No | Set the options list (array or collection) and declare which fields should be used for options values and labels. |
+| disableOptions(Closure $disabledOptions): self | No | Choose which options should be disabled by returning a boolean value from this closure result : `->disableOptions(function(array $option){})`. |
+| selectOptions(string $fieldToCompare, $valueToCompare): self | No | Choose which option should be selected, declaring the field and the value to compare against the declared options list. |
 
 **Notes**
-* in `single` mode, the selected() method second attribute only accept a string or an integer.
-* in `multiple` mode, the selected() method second attribute only accept an array.
+* in `single` mode, the `selectOptions()` method second attribute only accept a string or an integer.
+* in `multiple` mode, the `selectOptions()` method second attribute only accept an array.
 
 **Usage**
 
 ```php
 <SelectableAbstract>
-    // inherits FormAbstract methods
+    // Inherits FormAbstract methods
+    ->disablePlaceholder()
     ->options(collect([
         ['id' => 1, 'title' => 'Item 1', 'active' => true],
         ['id' => 2, 'title' => 'Item 2', 'active' => false],
     ]), 'id', 'title')
-    ->selected('id', 1)
-    // or ->selected('id', [1]) in multiple mode
-    ->disabled(fn(array $option) => ! $option['active'])
+    ->selectOptions('id', 1)
+    // or ->selectOptions('id', [1]) in multiple mode
+    ->disableOptions(fn(array $option) => ! $option['active'])
     ->multiple();
 ```
 
@@ -260,7 +262,7 @@
 
 ```php
 <SubmitAbstract>
-    // inherits ComponentAbstract methods
+    // Inherits ComponentAbstract methods
     ->label('Back to the users list')
     ->prepend('<i class="fas fa-hand-pointer"></i>')
     ->append('<i class="fas fa-hand-pointer"></i>');
@@ -288,7 +290,7 @@
 
 ```php
 <link>
-    // inherits SubmitAbstract methods
+    // Inherits SubmitAbstract methods
     ->url('https://website.com/admin/users')
     ->route('users.index');
 ```
@@ -315,7 +317,7 @@
 
 ```php
 <MediaAbstract>
-    // inherits ComponentAbstract methods
+    // Inherits ComponentAbstract methods
     ->src('https://yourapp.fr/public/media/audio.mp3');
 ```
 
@@ -344,7 +346,7 @@
 
 ```php
 <ImageAbstract>
-    // inherits MediaAbstract methods
+    // Inherits MediaAbstract methods
     ->alt('Image alt attribute')
     ->width(250)
     ->height(150)

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,15 +1,24 @@
 <?xml version="1.0"?>
 <ruleset name="PSR12">
 	<description>PSR-12 validation</description>
+    <!-- Included directories -->
     <file>./config</file>
 	<file>./src</file>
 	<file>./tests</file>
+    <!-- Excluded patterns -->
+    <exclude-pattern>*/*.js</exclude-pattern>
+    <exclude-pattern>*/*.css</exclude-pattern>
+    <exclude-pattern>*/*.xml</exclude-pattern>
+    <exclude-pattern>*/*.blade.php</exclude-pattern>
+    <!-- Configuration -->
+    <arg name="colors"/>
+    <arg value="p"/>
+    <!-- Rules -->
 	<rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
 		<exclude-pattern>./tests/*</exclude-pattern>
 	</rule>
     <rule ref="PSR1.Methods.CamelCapsMethodName">
         <exclude-pattern>./tests/*</exclude-pattern>
     </rule>
-    <exclude-pattern>*/*.blade.php</exclude-pattern>
 	<rule ref="PSR12"/>
 </ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -11,7 +11,7 @@ parameters:
     level: 5
 
     ignoreErrors:
-        #- '#Example of error to ignore#'
+        - '#Method Okipa\\LaravelBootstrapComponents\\Components\\Form\\Abstracts\\SelectableAbstract::disabled\(\) should return \$this\(Okipa\\LaravelBootstrapComponents\\Components\\Form\\Abstracts\\SelectableAbstract\) but returns Okipa\\LaravelBootstrapComponents\\Components\\Form\\Abstracts\\SelectableAbstract#'
 
     excludePaths:
         - ./*/*/FileToBeExcluded.php

--- a/resources/views/bootstrap-components/form/select.blade.php
+++ b/resources/views/bootstrap-components/form/select.blade.php
@@ -8,7 +8,7 @@
         @include('bootstrap-components::bootstrap-components.partials.prepend')
         <select id="{{ $componentId }}"{{ html_classes('component', 'custom-select', $componentClasses, $validationClass($errors ?? null)) }} name="{{ $name . ($multiple ? '[]' : '') }}"{{ html_attributes($multiple ? 'multiple' : null, $componentHtmlAttributes) }}>
             @if($placeholder)
-                <option value=""{{ html_attributes(count(array_filter(Arr::pluck($options, 'selected'))) ? null : ['selected' => 'selected']) }}>{{ $placeholder }}</option>
+                <option value=""{{ html_attributes(count(array_filter(Arr::pluck($options, 'selected'))) ? null : ['selected' => 'selected']) }}{{ html_attributes($disablePlaceholder ? ['disabled'] : null) }}>{{ $placeholder }}</option>
             @endif
             @foreach($options as $option)
                 <option value="{{ $option[$optionValueField] }}"{{ html_attributes(data_get($option, 'selected') ? ['selected' => 'selected'] : null, data_get($option, 'disabled') ? ['disabled'] : null) }}>{{ $option[$optionLabelField] }}</option>

--- a/src/Components/Form/Abstracts/SelectableAbstract.php
+++ b/src/Components/Form/Abstracts/SelectableAbstract.php
@@ -4,12 +4,15 @@ namespace Okipa\LaravelBootstrapComponents\Components\Form\Abstracts;
 
 use Closure;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 use Okipa\LaravelBootstrapComponents\Components\Form\Traits\SelectValidityChecks;
 
 abstract class SelectableAbstract extends FormAbstract
 {
     use SelectValidityChecks;
+
+    protected bool $disablePlaceholder = false;
+
+    protected bool $multiple = false;
 
     protected array $options = [];
 
@@ -24,7 +27,19 @@ abstract class SelectableAbstract extends FormAbstract
 
     protected ?Closure $disabledOptionsClosure = null;
 
-    protected bool $multiple = false;
+    public function disablePlaceholder(): self
+    {
+        $this->disablePlaceholder = true;
+
+        return $this;
+    }
+
+    public function multiple(bool $multiple = true): self
+    {
+        $this->multiple = $multiple;
+
+        return $this;
+    }
 
     /**
      * @param iterable $optionsList
@@ -44,12 +59,42 @@ abstract class SelectableAbstract extends FormAbstract
     }
 
     /**
+     * @param \Closure $disabledOptions
+     *
+     * @return $this
+     * @deprecated Use `disableOptions` method instead. This method will be removed in the next major version.
+     */
+    public function disabled(Closure $disabledOptions): self
+    {
+        return $this->disableOptions($disabledOptions);
+    }
+
+    public function disableOptions(Closure $disabledOptions): self
+    {
+        $this->disabledOptionsClosure = $disabledOptions;
+
+        return $this;
+    }
+
+    /**
+     * @param string $fieldToCompare
+     * @param int|string|array $valueToCompare
+     *
+     * @return $this
+     * @deprecated Use `selectOptions` method instead. This method will be removed in the next major version.
+     */
+    public function selected(string $fieldToCompare, $valueToCompare): self
+    {
+        return $this->selectOptions($fieldToCompare, $valueToCompare);
+    }
+
+    /**
      * @param string $fieldToCompare
      * @param int|string|array $valueToCompare
      *
      * @return $this
      */
-    public function selected(string $fieldToCompare, $valueToCompare): self
+    public function selectOptions(string $fieldToCompare, $valueToCompare): self
     {
         $this->selectedFieldToCompare = $fieldToCompare;
         $this->selectedValueToCompare = $valueToCompare;
@@ -57,28 +102,25 @@ abstract class SelectableAbstract extends FormAbstract
         return $this;
     }
 
-    public function disabled(Closure $disabledOptions): self
-    {
-        $this->disabledOptionsClosure = $disabledOptions;
-
-        return $this;
-    }
-
-    public function multiple(bool $multiple = true): self
-    {
-        $this->multiple = $multiple;
-
-        return $this;
-    }
-
     protected function getViewParams(): array
     {
         return array_merge(parent::getViewParams(), [
+            'disablePlaceholder' => $this->getDisablePlaceholder(),
+            'multiple' => $this->getMultiple(),
             'options' => $this->getOptions(),
             'optionValueField' => $this->getOptionValueField(),
             'optionLabelField' => $this->getOptionLabelField(),
-            'multiple' => $this->getMultiple(),
         ]);
+    }
+
+    protected function getDisablePlaceholder(): bool
+    {
+        return $this->disablePlaceholder;
+    }
+
+    protected function getMultiple(): bool
+    {
+        return $this->multiple;
     }
 
     protected function getOptions(): array
@@ -260,10 +302,5 @@ abstract class SelectableAbstract extends FormAbstract
     protected function getOptionLabelField(): ?string
     {
         return $this->optionLabelField;
-    }
-
-    protected function getMultiple(): bool
-    {
-        return $this->multiple;
     }
 }

--- a/src/Components/Form/Traits/SelectValidityChecks.php
+++ b/src/Components/Form/Traits/SelectValidityChecks.php
@@ -48,7 +48,7 @@ trait SelectValidityChecks
     {
         if ($this->selectedFieldToCompare && empty($option[$this->selectedFieldToCompare])) {
             throw new InvalidArgumentException(
-                get_class($this) . ' : Invalid selected() first $fieldToCompare argument. « '
+                get_class($this) . ' : Invalid selectOptions() first $fieldToCompare argument. « '
                 . $this->selectedFieldToCompare . ' »  does not exist the given first options() '
                 . '$optionsList argument.'
             );
@@ -75,7 +75,7 @@ trait SelectValidityChecks
     {
         if ($this->selectedValueToCompare && ! is_array($this->selectedValueToCompare)) {
             throw new InvalidArgumentException(
-                get_class($this) . ' : Invalid selected() second $valueToCompare argument. '
+                get_class($this) . ' : Invalid selectOptions() second $valueToCompare argument. '
                 . 'This argument has to be an array when the select() component is in multiple mode : « '
                 . gettype($this->selectedValueToCompare) . ' » type given.'
             );
@@ -90,7 +90,7 @@ trait SelectValidityChecks
             && ! is_int($this->selectedValueToCompare)
         ) {
             throw new InvalidArgumentException(
-                get_class($this) . ' : Invalid selected() second $valueToCompare argument. '
+                get_class($this) . ' : Invalid selectOptions() second $valueToCompare argument. '
                 . 'This argument has to be a string or an integer when the select() component is not '
                 . 'in multiple mode : « ' . gettype($this->selectedValueToCompare) . ' » type given.'
             );

--- a/tests/Unit/Form/Abstracts/SelectTestAbstract.php
+++ b/tests/Unit/Form/Abstracts/SelectTestAbstract.php
@@ -177,20 +177,20 @@ abstract class SelectTestAbstract extends InputTestAbstract
     }
 
     /** @test */
-    public function it_can_set_selected_option_with_no_option(): void
+    public function it_can_set_selected_options_with_no_option(): void
     {
-        $html = $this->getComponent()->name('id')->selected('id', 1)->toHtml();
+        $html = $this->getComponent()->name('id')->selectOptions('id', 1)->toHtml();
         self::assertStringContainsString('<select', $html);
     }
 
     /** @test */
-    public function it_cant_set_selected_option_from_wrong_type_value(): void
+    public function it_cant_set_selected_options_from_wrong_type_value(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $users = $this->createMultipleUsers(2);
         $this->getComponent()->name('id')
             ->options($users, 'id', 'name')
-            ->selected('id', ['test'])
+            ->selectOptions('id', ['test'])
             ->toHtml();
     }
 
@@ -203,7 +203,7 @@ abstract class SelectTestAbstract extends InputTestAbstract
             ->model($user)
             ->name('id')
             ->options($users, 'id', 'name')
-            ->selected('id', $users->get(1)->id)
+            ->selectOptions('id', $users->get(1)->id)
             ->toHtml();
         self::assertStringContainsString(
             '<option value="">validation.attributes.id</option>',
@@ -228,7 +228,7 @@ abstract class SelectTestAbstract extends InputTestAbstract
             ->model($user)
             ->name('name')
             ->options($users, 'name', 'name')
-            ->selected('name', $users->get(1)->name)
+            ->selectOptions('name', $users->get(1)->name)
             ->toHtml();
         self::assertStringContainsString(
             '<option value="">validation.attributes.name</option>',
@@ -280,7 +280,7 @@ abstract class SelectTestAbstract extends InputTestAbstract
         $html = $this->getComponent()
             ->model($model)
             ->name('name')
-            ->selected('id', $custom->id)
+            ->selectOptions('id', $custom->id)
             ->options($users, 'id', 'name')
             ->toHtml();
         self::assertStringContainsString(
@@ -310,7 +310,7 @@ abstract class SelectTestAbstract extends InputTestAbstract
         $html = $this->getComponent()
             ->model($model)
             ->name('name')
-            ->selected('id', $custom->id)
+            ->selectOptions('id', $custom->id)
             ->options($users, 'id', 'name')
             ->toHtml();
         self::assertStringContainsString(
@@ -341,7 +341,7 @@ abstract class SelectTestAbstract extends InputTestAbstract
         $html = $this->getComponent()
             ->model($model)
             ->name('name[0]')
-            ->selected('id', $custom->id)
+            ->selectOptions('id', $custom->id)
             ->options($users, 'id', 'name')
             ->toHtml();
         self::assertStringContainsString(
@@ -366,7 +366,7 @@ abstract class SelectTestAbstract extends InputTestAbstract
         $html = $this->getComponent()
             ->name('name')
             ->options($users, 'id', 'name')
-            ->disabled(function (array $option) {
+            ->disableOptions(function (array $option) {
                 return ! $option['active'];
             })
             ->toHtml();
@@ -402,8 +402,8 @@ abstract class SelectTestAbstract extends InputTestAbstract
         $user->companies = $companies->take(2)->pluck('id')->toArray();
         $html = $this->getComponent()->name('wrong')
             ->model($user)
-            ->options($companies, 'id', 'name')
             ->multiple()
+            ->options($companies, 'id', 'name')
             ->toHtml();
         self::assertStringContainsString(
             '<option value="" selected="selected">validation.attributes.wrong</option>',
@@ -436,8 +436,8 @@ abstract class SelectTestAbstract extends InputTestAbstract
         $html = $this->getComponent()
             ->model($user)
             ->name('companies')
-            ->options($companies, 'id', 'name')
             ->multiple()
+            ->options($companies, 'id', 'name')
             ->toHtml();
         self::assertStringContainsString(
             '<option value="" selected="selected">validation.attributes.companies</option>',
@@ -460,8 +460,8 @@ abstract class SelectTestAbstract extends InputTestAbstract
         $html = $this->getComponent()
             ->model($user)
             ->name('companies')
-            ->options($companies, 'id', 'name')
             ->multiple()
+            ->options($companies, 'id', 'name')
             ->toHtml();
         self::assertStringContainsString(
             '<option value="">validation.attributes.companies</option>',
@@ -484,9 +484,9 @@ abstract class SelectTestAbstract extends InputTestAbstract
         $companies = $this->createMultipleCompanies(5);
         $html = $this->getComponent()
             ->name('companies')
-            ->options($companies, 'id', 'name')
             ->multiple()
-            ->selected('id', [])
+            ->options($companies, 'id', 'name')
+            ->selectOptions('id', [])
             ->toHtml();
         self::assertStringContainsString(
             '<option value="" selected="selected">validation.attributes.companies</option>',
@@ -506,9 +506,9 @@ abstract class SelectTestAbstract extends InputTestAbstract
         $this->expectException(InvalidArgumentException::class);
         $companies = $this->createMultipleCompanies(5);
         $this->getComponent()->name('companies')
-            ->options($companies, 'id', 'name')
             ->multiple()
-            ->selected('id', 'test')
+            ->options($companies, 'id', 'name')
+            ->selectOptions('id', 'test')
             ->toHtml();
     }
 
@@ -521,9 +521,9 @@ abstract class SelectTestAbstract extends InputTestAbstract
         $selectedCompanies = $companies->sortByDesc('id')->take(2)->pluck('id')->toArray();
         $html = $this->getComponent()->name('companies')
             ->model($user)
-            ->options($companies, 'id', 'name')
             ->multiple()
-            ->selected('id', $selectedCompanies)
+            ->options($companies, 'id', 'name')
+            ->selectOptions('id', $selectedCompanies)
             ->toHtml();
         self::assertStringContainsString(
             '<option value="">validation.attributes.companies</option>',
@@ -549,9 +549,9 @@ abstract class SelectTestAbstract extends InputTestAbstract
         $selectedCompanies = $companies->sortByDesc('id')->take(2)->pluck('name')->toArray();
         $html = $this->getComponent()->name('companies')
             ->model($user)
-            ->options($companies, 'id', 'name')
             ->multiple()
-            ->selected('name', $selectedCompanies)
+            ->options($companies, 'id', 'name')
+            ->selectOptions('name', $selectedCompanies)
             ->toHtml();
         self::assertStringContainsString(
             '<option value="">validation.attributes.companies</option>',
@@ -583,9 +583,9 @@ abstract class SelectTestAbstract extends InputTestAbstract
         $this->call('GET', 'test');
         $html = $this->getComponent()->name('companies')
             ->model($user)
-            ->options($companies, 'id', 'name')
             ->multiple()
-            ->selected('id', $selectedCompanies)
+            ->options($companies, 'id', 'name')
+            ->selectOptions('id', $selectedCompanies)
             ->toHtml();
         self::assertStringContainsString(
             '<option value="">validation.attributes.companies</option>',
@@ -616,9 +616,9 @@ abstract class SelectTestAbstract extends InputTestAbstract
         $this->call('GET', 'test');
         $html = $this->getComponent()->name('companies')
             ->model($user)
-            ->options($companies, 'id', 'name')
             ->multiple()
-            ->selected('id', $selectedCompanies)
+            ->options($companies, 'id', 'name')
+            ->selectOptions('id', $selectedCompanies)
             ->toHtml();
         self::assertStringContainsString(
             '<option value="" selected="selected">validation.attributes.companies</option>',
@@ -647,9 +647,9 @@ abstract class SelectTestAbstract extends InputTestAbstract
         $this->call('GET', 'test');
         $html = $this->getComponent()->name('companies[0]')
             ->model($user)
-            ->options($companies, 'id', 'name')
             ->multiple()
-            ->selected('id', $selectedCompanies)
+            ->options($companies, 'id', 'name')
+            ->selectOptions('id', $selectedCompanies)
             ->toHtml();
         self::assertStringContainsString(
             '<option value="">validation.attributes.companies</option>',
@@ -769,6 +769,16 @@ abstract class SelectTestAbstract extends InputTestAbstract
             $html
         );
     }
+
+    public function it_can_disable_placeholder_option(): void
+    {
+        $html = $this->getComponent()->name('name')->disablePlaceholder()->toHtml();
+        self::assertStringNotContainsString(
+            '<option value="" selected="selected" disabled>',
+            $html
+        );
+    }
+
 
     /** @test */
     public function it_can_generate_default_component_id(): void


### PR DESCRIPTION
* Added the ability to disable the select component placeholder option with the new `->disablePlaceholder()` method
* Deprecations :
  * The select component `->disabled()` method usages should be replaced by `->disableOptions()`
  * The select component `->selected()` method usages should be replaced by `->selectOptions()`
  * These deprecated methods will be removed in the next major version
  * These renaming are improving understanding about what these methods are actually doing